### PR TITLE
fix: ffmpeg未導入時は録画フレーム取得と変換をスキップ

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ recordings/               （生成）テスト録画（MP4）
 
 ## 動画録画
 
-テスト中 500ms 間隔でブラウザ画面をキャプチャし、テスト終了後に ffmpeg で MP4 に変換する。ffmpeg 未インストール時はフレーム画像が `recordings/frames/` に残る。
+ffmpeg が利用可能な場合のみ、テスト中 500ms 間隔でブラウザ画面をキャプチャし、テスト終了後に MP4 に変換する。ffmpeg 未インストール時はフレームキャプチャ自体をスキップし、動画変換も実行しない。
 
 > **なぜ Playwright の `recordVideo` を使わないのか？**
 > Stagehand v3 は Playwright の BrowserContext ではなく CDP 直接接続の `V3Context` でブラウザを制御しており、Playwright の録画 API にアクセスできない。

--- a/support/recording.ts
+++ b/support/recording.ts
@@ -8,6 +8,33 @@ export interface Recorder {
   injectFrames: (n?: number) => Promise<void>;
 }
 
+let ffmpegAvailableCache: boolean | undefined;
+
+/**
+ * ffmpeg コマンドが利用可能かを確認する。
+ * 結果はプロセス内でキャッシュされる。
+ */
+export function hasFfmpegCommand(): boolean {
+  if (ffmpegAvailableCache !== undefined) return ffmpegAvailableCache;
+
+  try {
+    execSync("ffmpeg -version", { stdio: "ignore" });
+    ffmpegAvailableCache = true;
+  } catch {
+    ffmpegAvailableCache = false;
+  }
+
+  return ffmpegAvailableCache;
+}
+
+/** ffmpeg 未インストール時用の no-op recorder */
+export function createNoopRecorder(): Recorder {
+  return {
+    stop: async () => 0,
+    injectFrames: async () => {},
+  };
+}
+
 /**
  * ページのフレームキャプチャを開始する。
  * 返り値の stop() を呼ぶとキャプチャを終了し、撮影したフレーム数を返す。

--- a/support/stagehand.ts
+++ b/support/stagehand.ts
@@ -8,7 +8,13 @@ import {
   type TestContext,
 } from "./context.js";
 import { createScreenshotHelper } from "./screenshot.js";
-import { startRecording, framesToVideo, type Recorder } from "./recording.js";
+import {
+  startRecording,
+  framesToVideo,
+  hasFfmpegCommand,
+  createNoopRecorder,
+  type Recorder,
+} from "./recording.js";
 
 const FRAME_INTERVAL_MS = 500;
 
@@ -25,7 +31,12 @@ export async function initStagehand(originUrl: string): Promise<{
     if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true });
     fs.mkdirSync(dir, { recursive: true });
   }
-  fs.mkdirSync(FRAMES_DIR, { recursive: true });
+  const ffmpegAvailable = hasFfmpegCommand();
+  if (ffmpegAvailable) {
+    fs.mkdirSync(FRAMES_DIR, { recursive: true });
+  } else {
+    console.info("ffmpeg not found: skip frame capture and video conversion");
+  }
 
   const stagehand = new Stagehand({
     env: "LOCAL",
@@ -40,7 +51,9 @@ export async function initStagehand(originUrl: string): Promise<{
   const page = stagehand.context.pages()[0];
 
   const screenshotFn = createScreenshotHelper(page, SCREENSHOT_DIR);
-  const recorder = startRecording(page, FRAMES_DIR, FRAME_INTERVAL_MS);
+  const recorder = ffmpegAvailable
+    ? startRecording(page, FRAMES_DIR, FRAME_INTERVAL_MS)
+    : createNoopRecorder();
 
   const ctx = createTestContext(stagehand, page, recorder, screenshotFn, originUrl);
 


### PR DESCRIPTION
## 概要
Issue #2 に対応し、ffmpeg がない環境では録画処理自体をスキップするようにしました。

Closes #2

## 変更内容
- `support/recording.ts`
  - `hasFfmpegCommand()` を追加（結果をプロセス内キャッシュ）
  - `createNoopRecorder()` を追加
- `support/stagehand.ts`
  - 初期化時に ffmpeg の有無を判定
  - ffmpeg あり: 従来どおり `startRecording()`
  - ffmpeg なし: `createNoopRecorder()` を使用してフレーム取得を実施しない
- `README.md`
  - ffmpeg 未導入時はフレーム取得・動画変換を行わない仕様へ説明更新

## 動作確認
- ffmpeg あり: `pnpm e2e` で 5/5 pass
- ffmpeg なし相当 (`PATH=/usr/bin:/bin`): `pnpm e2e` で 5/5 pass
  - ログに `ffmpeg not found: skip frame capture and video conversion` を確認
