### PR TITLE
chore: add biome and framework typecheck baseline

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "security": {
+        "noGlobalEval": "off"
+      },
+      "style": {
+        "useNodejsImportProtocol": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  },
+  "files": {
+    "includes": ["packages/**/*.ts", "examples/**/*.ts", "*.json", "*.md"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "e2e": "pnpm --filter @voreux/example-cfe-jp e2e",
-    "e2e:self-heal": "pnpm --filter @voreux/example-cfe-jp e2e:self-heal"
+    "e2e:self-heal": "pnpm --filter @voreux/example-cfe-jp e2e:self-heal",
+    "format": "biome format --write .",
+    "lint": "biome lint .",
+    "check": "biome check .",
+    "typecheck": "pnpm --filter voreux exec tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.9"
   }
 }

--- a/packages/voreux/src/config.ts
+++ b/packages/voreux/src/config.ts
@@ -67,13 +67,16 @@ export const frameworkConfig: E2EFrameworkConfig = {
   },
   navigation: {
     timeoutMs: Math.max(1, toInt(process.env.E2E_NAV_TIMEOUT_MS, 10000)),
-    pollIntervalMs: Math.max(1, toInt(process.env.E2E_NAV_POLL_INTERVAL_MS, 300)),
+    pollIntervalMs: Math.max(
+      1,
+      toInt(process.env.E2E_NAV_POLL_INTERVAL_MS, 300),
+    ),
   },
   visualRegression: {
     mismatchThreshold: clamp(
       toFloat(process.env.E2E_VISUAL_DIFF_THRESHOLD, 0.1),
       0,
-      1
+      1,
     ),
   },
 };

--- a/packages/voreux/src/context.ts
+++ b/packages/voreux/src/context.ts
@@ -1,14 +1,14 @@
-import path from "path";
 import type { Stagehand } from "@browserbasehq/stagehand";
-import type { ScreenshotFn } from "./screenshot.js";
-import type { Recorder } from "./recording.js";
-import { compareWithBaseline, saveBaseline } from "./screenshot.js";
+import path from "path";
+import { frameworkConfig } from "./config.js";
 import {
   highlightElement,
   highlightElements,
   removeHighlights,
 } from "./highlight.js";
-import { frameworkConfig } from "./config.js";
+import type { Recorder } from "./recording.js";
+import type { ScreenshotFn } from "./screenshot.js";
+import { compareWithBaseline, saveBaseline } from "./screenshot.js";
 
 // ----------------------------------------------------------------
 // 定数
@@ -19,7 +19,8 @@ export const RECORDING_DIR = path.resolve("recordings");
 export const FRAMES_DIR = path.join(RECORDING_DIR, "frames");
 export const BASELINES_DIR = path.resolve("baselines");
 
-export const VISUAL_DIFF_THRESHOLD = frameworkConfig.visualRegression.mismatchThreshold;
+export const VISUAL_DIFF_THRESHOLD =
+  frameworkConfig.visualRegression.mismatchThreshold;
 
 // ----------------------------------------------------------------
 // VisualRegressionError
@@ -30,7 +31,7 @@ export class VisualRegressionError extends Error {
   mismatchRatio: number;
   constructor(diffPath: string, mismatchRatio: number) {
     super(
-      `Visual regression detected (${(mismatchRatio * 100).toFixed(1)}% mismatch). Diff: ${diffPath}`
+      `Visual regression detected (${(mismatchRatio * 100).toFixed(1)}% mismatch). Diff: ${diffPath}`,
     );
     this.name = "VisualRegressionError";
     this.diffPath = diffPath;
@@ -62,7 +63,10 @@ export interface TestContext {
   highlightObserved: (actions: any[], screenshotName: string) => Promise<void>;
 
   /** observe() で要素を探し、単一ハイライト → screenshot → 録画フレーム注入 → ハイライト除去 */
-  highlightTarget: (instruction: string, screenshotName: string) => Promise<void>;
+  highlightTarget: (
+    instruction: string,
+    screenshotName: string,
+  ) => Promise<void>;
 }
 
 export function createTestContext(
@@ -70,7 +74,7 @@ export function createTestContext(
   page: any,
   recorder: Recorder,
   screenshotFn: ScreenshotFn,
-  originUrl: string
+  originUrl: string,
 ): TestContext {
   let lastComparisonSsPath: string | null = null;
 
@@ -90,9 +94,11 @@ export function createTestContext(
       let resultPage: any = null;
       while (Date.now() < deadline) {
         // 新しく開いたページのみチェック
-        const newPages = stagehand.context.pages().filter((p: any) => !initialPages.has(p));
+        const newPages = stagehand.context
+          .pages()
+          .filter((p: any) => !initialPages.has(p));
         const matchedPage = newPages.find((p: any) =>
-          p.url().includes(urlPattern)
+          p.url().includes(urlPattern),
         );
         if (matchedPage) {
           resultPage = matchedPage;
@@ -104,13 +110,13 @@ export function createTestContext(
           break;
         }
         await new Promise((r) =>
-          setTimeout(r, frameworkConfig.navigation.pollIntervalMs)
+          setTimeout(r, frameworkConfig.navigation.pollIntervalMs),
         );
       }
 
       if (!resultPage) {
         throw new Error(
-          `Navigation failed: no page matching "${urlPattern}" found`
+          `Navigation failed: no page matching "${urlPattern}" found`,
         );
       }
 
@@ -131,7 +137,10 @@ export function createTestContext(
         diffPath,
       });
 
-      if (!comparison.skipped && comparison.mismatchRatio > VISUAL_DIFF_THRESHOLD) {
+      if (
+        !comparison.skipped &&
+        comparison.mismatchRatio > VISUAL_DIFF_THRESHOLD
+      ) {
         throw new VisualRegressionError(diffPath, comparison.mismatchRatio);
       }
     },
@@ -146,7 +155,9 @@ export function createTestContext(
       await highlightElements(page, actions);
       try {
         await screenshotFn(screenshotName);
-        await recorder.injectFrames(frameworkConfig.videoRecording.injectFrameCount);
+        await recorder.injectFrames(
+          frameworkConfig.videoRecording.injectFrameCount,
+        );
       } finally {
         await removeHighlights(page);
       }
@@ -161,7 +172,9 @@ export function createTestContext(
         });
         try {
           await screenshotFn(screenshotName);
-          await recorder.injectFrames(frameworkConfig.videoRecording.injectFrameCount);
+          await recorder.injectFrames(
+            frameworkConfig.videoRecording.injectFrameCount,
+          );
         } finally {
           await removeHighlights(page);
         }

--- a/packages/voreux/src/highlight.ts
+++ b/packages/voreux/src/highlight.ts
@@ -43,7 +43,7 @@ function resolveElement(selector: string): string {
 export async function highlightElement(
   page: any,
   selector: string,
-  opts: HighlightElementOpts = {}
+  opts: HighlightElementOpts = {},
 ): Promise<void> {
   const {
     showCursor = false,
@@ -65,7 +65,10 @@ export async function highlightElement(
       const el = eval(resolveExpr) as Element | null;
       if (!el) return;
 
-      (el as HTMLElement).scrollIntoView?.({ block: "center", behavior: "instant" });
+      (el as HTMLElement).scrollIntoView?.({
+        block: "center",
+        behavior: "instant",
+      });
 
       const rect = el.getBoundingClientRect();
       const scrollX = window.scrollX;
@@ -79,8 +82,8 @@ export async function highlightElement(
         container.style.position = "absolute";
         container.style.top = "0";
         container.style.left = "0";
-        container.style.width = document.documentElement.scrollWidth + "px";
-        container.style.height = document.documentElement.scrollHeight + "px";
+        container.style.width = `${document.documentElement.scrollWidth}px`;
+        container.style.height = `${document.documentElement.scrollHeight}px`;
         container.style.pointerEvents = "none";
         container.style.zIndex = "2147483647";
         document.documentElement.appendChild(container);
@@ -89,10 +92,10 @@ export async function highlightElement(
       // Overlay box
       const overlay = document.createElement("div");
       overlay.style.position = "absolute";
-      overlay.style.left = (rect.left + scrollX - 3) + "px";
-      overlay.style.top = (rect.top + scrollY - 3) + "px";
-      overlay.style.width = (rect.width + 6) + "px";
-      overlay.style.height = (rect.height + 6) + "px";
+      overlay.style.left = `${rect.left + scrollX - 3}px`;
+      overlay.style.top = `${rect.top + scrollY - 3}px`;
+      overlay.style.width = `${rect.width + 6}px`;
+      overlay.style.height = `${rect.height + 6}px`;
       overlay.style.background = overlayColor;
       overlay.style.border = `3px solid ${borderColor}`;
       overlay.style.borderRadius = "4px";
@@ -104,8 +107,8 @@ export async function highlightElement(
         const badge = document.createElement("div");
         badge.textContent = label;
         badge.style.position = "absolute";
-        badge.style.left = (rect.left + scrollX - 3) + "px";
-        badge.style.top = (rect.top + scrollY - 22) + "px";
+        badge.style.left = `${rect.left + scrollX - 3}px`;
+        badge.style.top = `${rect.top + scrollY - 22}px`;
         badge.style.background = borderColor;
         badge.style.color = "#fff";
         badge.style.fontSize = "11px";
@@ -122,8 +125,8 @@ export async function highlightElement(
         const cursor = document.createElement("div");
         cursor.innerHTML = cursorSvg;
         cursor.style.position = "absolute";
-        cursor.style.left = (rect.left + scrollX + rect.width / 2) + "px";
-        cursor.style.top = (rect.top + scrollY + rect.height / 2) + "px";
+        cursor.style.left = `${rect.left + scrollX + rect.width / 2}px`;
+        cursor.style.top = `${rect.top + scrollY + rect.height / 2}px`;
         container.appendChild(cursor);
       }
     },
@@ -135,7 +138,7 @@ export async function highlightElement(
       label,
       cursorSvg: CURSOR_SVG,
       containerId: HIGHLIGHT_CONTAINER_ID,
-    }
+    },
   );
 }
 
@@ -151,7 +154,7 @@ interface ObservedAction {
  */
 export async function highlightElements(
   page: any,
-  actions: ObservedAction[]
+  actions: ObservedAction[],
 ): Promise<void> {
   await page.evaluate(
     ({ actions, palette, containerId }: any) => {
@@ -163,8 +166,8 @@ export async function highlightElements(
         container.style.position = "absolute";
         container.style.top = "0";
         container.style.left = "0";
-        container.style.width = document.documentElement.scrollWidth + "px";
-        container.style.height = document.documentElement.scrollHeight + "px";
+        container.style.width = `${document.documentElement.scrollWidth}px`;
+        container.style.height = `${document.documentElement.scrollHeight}px`;
         container.style.pointerEvents = "none";
         container.style.zIndex = "2147483647";
         document.documentElement.appendChild(container);
@@ -178,7 +181,13 @@ export async function highlightElements(
         try {
           if (action.selector.startsWith("xpath=")) {
             const xpath = action.selector.slice("xpath=".length);
-            el = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue as Element;
+            el = document.evaluate(
+              xpath,
+              document,
+              null,
+              XPathResult.FIRST_ORDERED_NODE_TYPE,
+              null,
+            ).singleNodeValue as Element;
           } else {
             el = document.querySelector(action.selector);
           }
@@ -194,10 +203,10 @@ export async function highlightElements(
         // Overlay box
         const overlay = document.createElement("div");
         overlay.style.position = "absolute";
-        overlay.style.left = (rect.left + scrollX - 2) + "px";
-        overlay.style.top = (rect.top + scrollY - 2) + "px";
-        overlay.style.width = (rect.width + 4) + "px";
-        overlay.style.height = (rect.height + 4) + "px";
+        overlay.style.left = `${rect.left + scrollX - 2}px`;
+        overlay.style.top = `${rect.top + scrollY - 2}px`;
+        overlay.style.width = `${rect.width + 4}px`;
+        overlay.style.height = `${rect.height + 4}px`;
         overlay.style.background = color.bg;
         overlay.style.border = `2px solid ${color.border}`;
         overlay.style.borderRadius = "3px";
@@ -208,8 +217,8 @@ export async function highlightElements(
         const badge = document.createElement("div");
         badge.textContent = String(i + 1);
         badge.style.position = "absolute";
-        badge.style.left = (rect.left + scrollX - 2) + "px";
-        badge.style.top = (rect.top + scrollY - 20) + "px";
+        badge.style.left = `${rect.left + scrollX - 2}px`;
+        badge.style.top = `${rect.top + scrollY - 20}px`;
         badge.style.background = color.border;
         badge.style.color = "#fff";
         badge.style.fontSize = "11px";
@@ -228,8 +237,8 @@ export async function highlightElements(
           const tip = document.createElement("div");
           tip.textContent = `${i + 1}. ${action.description}`;
           tip.style.position = "absolute";
-          tip.style.left = (rect.left + scrollX - 2) + "px";
-          tip.style.top = (rect.top + scrollY + rect.height + 4) + "px";
+          tip.style.left = `${rect.left + scrollX - 2}px`;
+          tip.style.top = `${rect.top + scrollY + rect.height + 4}px`;
           tip.style.background = "rgba(0,0,0,0.75)";
           tip.style.color = "#fff";
           tip.style.fontSize = "10px";
@@ -245,10 +254,13 @@ export async function highlightElements(
       }
     },
     {
-      actions: actions.map((a) => ({ selector: a.selector, description: a.description })),
+      actions: actions.map((a) => ({
+        selector: a.selector,
+        description: a.description,
+      })),
       palette: COLOR_PALETTE,
       containerId: HIGHLIGHT_CONTAINER_ID,
-    }
+    },
   );
 }
 

--- a/packages/voreux/src/index.ts
+++ b/packages/voreux/src/index.ts
@@ -1,2 +1,2 @@
-export { defineScenarioSuite } from "./scenario.js";
 export type { ScenarioStep, ScenarioSuiteOptions } from "./scenario.js";
+export { defineScenarioSuite } from "./scenario.js";

--- a/packages/voreux/src/recording.ts
+++ b/packages/voreux/src/recording.ts
@@ -1,6 +1,6 @@
-import path from "path";
-import fs from "fs";
 import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
 
 export interface Recorder {
   stop: () => Promise<number>;
@@ -42,7 +42,7 @@ export function createNoopRecorder(): Recorder {
 export function startRecording(
   page: any,
   framesDir: string,
-  intervalMs = 500
+  intervalMs = 500,
 ): Recorder {
   let frameIndex = 0;
   let stopped = false;
@@ -54,7 +54,7 @@ export function startRecording(
         try {
           const filePath = path.join(
             framesDir,
-            `frame-${String(frameIndex).padStart(5, "0")}.png`
+            `frame-${String(frameIndex).padStart(5, "0")}.png`,
           );
           await page.screenshot({ path: filePath });
           frameIndex++;
@@ -75,7 +75,7 @@ export function startRecording(
         for (let i = 0; i < n; i++) {
           const filePath = path.join(
             framesDir,
-            `frame-${String(frameIndex).padStart(5, "0")}.png`
+            `frame-${String(frameIndex).padStart(5, "0")}.png`,
           );
           await page.screenshot({ path: filePath });
           frameIndex++;
@@ -98,22 +98,19 @@ export function startRecording(
 export function framesToVideo(
   framesDir: string,
   outputDir: string,
-  fps: number
+  fps: number,
 ): string | null {
   const outputPath = path.join(outputDir, "test-recording.mp4");
   const pattern = path.join(framesDir, "frame-%05d.png");
   try {
     execSync(
-      `ffmpeg -y -framerate ${fps} -i "${pattern}" -c:v libx264 -pix_fmt yuv420p "${outputPath}" 2>/dev/null`
+      `ffmpeg -y -framerate ${fps} -i "${pattern}" -c:v libx264 -pix_fmt yuv420p "${outputPath}" 2>/dev/null`,
     );
     // フレーム画像を削除
     fs.rmSync(framesDir, { recursive: true });
     return outputPath;
   } catch {
-    console.error(
-      "  ffmpeg conversion failed. Raw frames kept in:",
-      framesDir
-    );
+    console.error("  ffmpeg conversion failed. Raw frames kept in:", framesDir);
     return null;
   }
 }

--- a/packages/voreux/src/scenario.ts
+++ b/packages/voreux/src/scenario.ts
@@ -1,8 +1,8 @@
-import { describe, test, beforeAll, afterAll, afterEach } from "vitest";
-import { initStagehand, closeStagehand } from "./stagehand.js";
+import { afterAll, afterEach, beforeAll, describe, test } from "vitest";
 import type { TestContext } from "./context.js";
 import type { Recorder } from "./recording.js";
 import { withSelfHeal } from "./self-heal.js";
+import { closeStagehand, initStagehand } from "./stagehand.js";
 
 export interface ScenarioStep {
   name: string;
@@ -42,7 +42,7 @@ export function defineScenarioSuite({
     afterAll(async () => {
       if (_ctx && _recorder) {
         await closeStagehand(_ctx, _recorder).catch((e) =>
-          console.error("closeStagehand error:", e)
+          console.error("closeStagehand error:", e),
         );
       }
     });

--- a/packages/voreux/src/screenshot.ts
+++ b/packages/voreux/src/screenshot.ts
@@ -1,5 +1,5 @@
-import path from "path";
 import fs from "fs";
+import path from "path";
 import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
 
@@ -9,10 +9,7 @@ export type ScreenshotFn = (name: string, targetPage?: any) => Promise<string>;
  * スクリーンショット撮影ヘルパーを生成する。
  * 返り値の関数は名前を受け取ってスクリーンショットを保存し、ファイルパスを返す。
  */
-export function createScreenshotHelper(
-  page: any,
-  dir: string
-): ScreenshotFn {
+export function createScreenshotHelper(page: any, dir: string): ScreenshotFn {
   return async (name: string, targetPage = page) => {
     const filePath = path.join(dir, `${name}.png`);
     try {
@@ -31,7 +28,7 @@ export function createScreenshotHelper(
 export function compareWithBaseline(
   currentPath: string,
   baselineName: string,
-  opts: { baselinesDir: string; diffPath: string }
+  opts: { baselinesDir: string; diffPath: string },
 ): { mismatchRatio: number; diffSaved: boolean; skipped: boolean } {
   const baselinePath = path.join(opts.baselinesDir, `${baselineName}.png`);
 
@@ -55,7 +52,7 @@ export function compareWithBaseline(
     diff.data,
     width,
     height,
-    { threshold: 0.1 }
+    { threshold: 0.1 },
   );
 
   const mismatchRatio = numDiffPixels / (width * height);
@@ -69,7 +66,7 @@ export function compareWithBaseline(
 export function saveBaseline(
   screenshotPath: string,
   baselineName: string,
-  baselinesDir: string
+  baselinesDir: string,
 ): string {
   if (!fs.existsSync(baselinesDir)) {
     fs.mkdirSync(baselinesDir, { recursive: true });

--- a/packages/voreux/src/self-heal.ts
+++ b/packages/voreux/src/self-heal.ts
@@ -1,8 +1,8 @@
-import path from "path";
 import fs from "fs";
+import path from "path";
+import { frameworkConfig } from "./config.js";
 import type { TestContext } from "./context.js";
 import { VisualRegressionError } from "./context.js";
-import { frameworkConfig } from "./config.js";
 
 /**
  * セルフヒール回復処理:
@@ -41,7 +41,7 @@ async function performSelfHeal(ctx: TestContext): Promise<void> {
  */
 export async function withSelfHeal(
   ctx: TestContext,
-  fn: () => Promise<void>
+  fn: () => Promise<void>,
 ): Promise<void> {
   try {
     await fn();
@@ -49,7 +49,9 @@ export async function withSelfHeal(
     if (err instanceof VisualRegressionError) throw err;
     if (process.env.SELF_HEAL !== "1") throw err;
 
-    console.log("  [self-heal] Test failed, performing recovery and retrying...");
+    console.log(
+      "  [self-heal] Test failed, performing recovery and retrying...",
+    );
     await performSelfHeal(ctx);
     await fn();
   }

--- a/packages/voreux/src/stagehand.ts
+++ b/packages/voreux/src/stagehand.ts
@@ -1,21 +1,21 @@
 import { Stagehand } from "@browserbasehq/stagehand";
 import fs from "fs";
+import { frameworkConfig } from "./config.js";
 import {
-  SCREENSHOT_DIR,
-  RECORDING_DIR,
-  FRAMES_DIR,
   createTestContext,
+  FRAMES_DIR,
+  RECORDING_DIR,
+  SCREENSHOT_DIR,
   type TestContext,
 } from "./context.js";
-import { createScreenshotHelper } from "./screenshot.js";
 import {
-  startRecording,
+  createNoopRecorder,
   framesToVideo,
   hasFfmpegCommand,
-  createNoopRecorder,
   type Recorder,
+  startRecording,
 } from "./recording.js";
-import { frameworkConfig } from "./config.js";
+import { createScreenshotHelper } from "./screenshot.js";
 
 /**
  * Stagehand を初期化し、テスト実行に必要な環境を準備する。
@@ -54,11 +54,17 @@ export async function initStagehand(originUrl: string): Promise<{
     ? startRecording(
         page,
         FRAMES_DIR,
-        frameworkConfig.videoRecording.frameIntervalMs
+        frameworkConfig.videoRecording.frameIntervalMs,
       )
     : createNoopRecorder();
 
-  const ctx = createTestContext(stagehand, page, recorder, screenshotFn, originUrl);
+  const ctx = createTestContext(
+    stagehand,
+    page,
+    recorder,
+    screenshotFn,
+    originUrl,
+  );
 
   return { ctx, recorder };
 }
@@ -69,7 +75,7 @@ export async function initStagehand(originUrl: string): Promise<{
  */
 export async function closeStagehand(
   ctx: TestContext,
-  recorder: Recorder
+  recorder: Recorder,
 ): Promise<void> {
   const totalFrames = await recorder.stop();
   await ctx.stagehand.close();
@@ -77,7 +83,7 @@ export async function closeStagehand(
   if (totalFrames > 0) {
     const safeInterval = Math.max(
       frameworkConfig.videoRecording.frameIntervalMs,
-      1
+      1,
     );
     const fps = Math.round(1000 / safeInterval);
     framesToVideo(FRAMES_DIR, RECORDING_DIR, fps);

--- a/packages/voreux/tests/public-api.test.ts
+++ b/packages/voreux/tests/public-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { defineScenarioSuite } from "../src/index.js";
 
 describe("voreux public api", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.9
+        version: 2.4.9
 
   examples/cfe-jp:
     dependencies:
@@ -159,6 +163,59 @@ packages:
 
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
+
+  '@biomejs/biome@2.4.9':
+    resolution: {integrity: sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.9':
+    resolution: {integrity: sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.9':
+    resolution: {integrity: sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.9':
+    resolution: {integrity: sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.4.9':
+    resolution: {integrity: sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.9':
+    resolution: {integrity: sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.4.9':
+    resolution: {integrity: sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.4.9':
+    resolution: {integrity: sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.9':
+    resolution: {integrity: sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@browserbasehq/sdk@2.6.0':
     resolution: {integrity: sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA==}
@@ -2099,6 +2156,41 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@biomejs/biome@2.4.9':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.9
+      '@biomejs/cli-darwin-x64': 2.4.9
+      '@biomejs/cli-linux-arm64': 2.4.9
+      '@biomejs/cli-linux-arm64-musl': 2.4.9
+      '@biomejs/cli-linux-x64': 2.4.9
+      '@biomejs/cli-linux-x64-musl': 2.4.9
+      '@biomejs/cli-win32-arm64': 2.4.9
+      '@biomejs/cli-win32-x64': 2.4.9
+
+  '@biomejs/cli-darwin-arm64@2.4.9':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.9':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.9':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.9':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.9':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.9':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.9':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.9':
+    optional: true
 
   '@browserbasehq/sdk@2.6.0':
     dependencies:


### PR DESCRIPTION
## Summary
- add Biome as the formatter/linter for the workspace
- add root scripts for format/lint/check/typecheck
- enforce framework-only TypeScript typecheck for `packages/voreux`
- keep CI and unit test expansion out of scope for this PR

## Changes
- add `biome.json`
- add `@biomejs/biome` to workspace devDependencies
- add root scripts:
  - `pnpm format`
  - `pnpm lint`
  - `pnpm check`
  - `pnpm typecheck`
- reformat framework files under `packages/voreux/src`
- keep example app as sample-only; no extra test scope added here

## Notes
- CI is intentionally split out into a separate issue/PR: #6
- unit test expansion is also intentionally out of scope for this PR
- Biome is used as the initial formatter/linter baseline; ESLint can be added later only if a concrete gap appears


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Biomeコードフォーマッタをプロジェクトに導入し、コード品質チェック用スクリプト（format、lint、check、typecheck）を追加しました。

* **Style**
  * コード全体で一貫した書式スタイルを適用しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->