### PR TITLE
ci: add framework validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,22 @@ on:
 jobs:
   framework:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.28.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow for the repository
- validate formatting/lint, framework typecheck, build, and framework tests
- keep the example app out of the required validation scope for now

## What CI runs
- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter voreux build`
- `pnpm --filter voreux test`

## Scope note
This intentionally focuses on the reusable framework package first. The example app remains sample-oriented and is not made a required CI target in this PR.

Closes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CIワークフローを追加。プルリクエストと main へのプッシュで自動実行され、実行の重複をキャンセルします。依存関係のインストール、コードチェック、型検査、指定パッケージのビルド、およびテストを順次実行して、変更の品質を自動検証します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->