### PR TITLE
feat: throw ArtifactNameCollisionError on duplicate screenshot names

### DIFF
--- a/packages/voreux/src/index.ts
+++ b/packages/voreux/src/index.ts
@@ -12,3 +12,7 @@ export {
 export type { TestContext } from "./context.js";
 export type { ScenarioStep, ScenarioSuiteOptions } from "./scenario.js";
 export { defineScenarioSuite } from "./scenario.js";
+export {
+  ArtifactNameCollisionError,
+  ImageSizeMismatchError,
+} from "./screenshot.js";

--- a/packages/voreux/src/screenshot.ts
+++ b/packages/voreux/src/screenshot.ts
@@ -62,11 +62,17 @@ export function createScreenshotHelper(
   dir: string,
   recorder?: Recorder,
 ): ScreenshotFn {
+  // クロージャ内で予約済みパスを管理する。
+  // fs.existsSync によるチェックは TOCTOU で破られるため、
+  // チェックと登録を単一の同期操作として行う。
+  const reservedPaths = new Set<string>();
+
   return async (name: string, targetPage = page) => {
     const filePath = path.join(dir, `${sanitizeArtifactName(name)}.png`);
-    if (fs.existsSync(filePath)) {
+    if (reservedPaths.has(filePath)) {
       throw new ArtifactNameCollisionError(filePath);
     }
+    reservedPaths.add(filePath);
     recorder?.pause();
     try {
       await recorder?.captureFrameNow();

--- a/packages/voreux/src/screenshot.ts
+++ b/packages/voreux/src/screenshot.ts
@@ -73,6 +73,7 @@ export function createScreenshotHelper(
       throw new ArtifactNameCollisionError(filePath);
     }
     reservedPaths.add(filePath);
+    let succeeded = false;
     recorder?.pause();
     try {
       await recorder?.captureFrameNow();
@@ -81,12 +82,18 @@ export function createScreenshotHelper(
       } catch {
         await targetPage.screenshot({ path: filePath });
       }
+      succeeded = true;
       await new Promise((resolve) =>
         setTimeout(resolve, POST_VRT_STABILIZE_MS),
       );
       await recorder?.captureFrameNow();
     } finally {
       recorder?.resume();
+      // 撮影が失敗した場合はファイルが存在しないので予約を解放する。
+      // 次回の呼び出しで再試行できるようにするため。
+      if (!succeeded) {
+        reservedPaths.delete(filePath);
+      }
     }
     return filePath;
   };

--- a/packages/voreux/src/screenshot.ts
+++ b/packages/voreux/src/screenshot.ts
@@ -4,6 +4,15 @@ import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
 import type { Recorder } from "./recording.js";
 
+export class ArtifactNameCollisionError extends Error {
+  constructor(public filePath: string) {
+    super(
+      `Screenshot artifact already exists: ${filePath}\nEach screenshot name must be unique within a run. Use a scenario-scoped, descriptive name at the callsite.`,
+    );
+    this.name = "ArtifactNameCollisionError";
+  }
+}
+
 export class ImageSizeMismatchError extends Error {
   constructor(
     public currentSize: { width: number; height: number },
@@ -55,6 +64,9 @@ export function createScreenshotHelper(
 ): ScreenshotFn {
   return async (name: string, targetPage = page) => {
     const filePath = path.join(dir, `${sanitizeArtifactName(name)}.png`);
+    if (fs.existsSync(filePath)) {
+      throw new ArtifactNameCollisionError(filePath);
+    }
     recorder?.pause();
     try {
       await recorder?.captureFrameNow();

--- a/packages/voreux/src/screenshot.ts
+++ b/packages/voreux/src/screenshot.ts
@@ -62,6 +62,10 @@ export function createScreenshotHelper(
   dir: string,
   recorder?: Recorder,
 ): ScreenshotFn {
+  // ヘルパー生成時にディレクトリを作成しておく。
+  // 呼び出し元に依存せずファイル書き込みを保証するため。
+  fs.mkdirSync(dir, { recursive: true });
+
   // クロージャ内で予約済みパスを管理する。
   // fs.existsSync によるチェックは TOCTOU で破られるため、
   // チェックと登録を単一の同期操作として行う。

--- a/packages/voreux/tests/screenshot.test.ts
+++ b/packages/voreux/tests/screenshot.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  ArtifactNameCollisionError,
   createScreenshotHelper,
   sanitizeArtifactName,
 } from "../src/screenshot.js";
@@ -44,5 +45,24 @@ describe("screenshot helpers", () => {
     expect(actualPath).toBe(path.join(dir, "error-hover-submenu.png"));
     expect(screenshot).toHaveBeenCalledOnce();
     expect(fs.existsSync(actualPath)).toBe(true);
+  });
+
+  it("throws ArtifactNameCollisionError when the sanitized path already exists", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "voreux-shots-"));
+    tempDirs.push(dir);
+
+    const screenshot = vi.fn(async ({ path: filePath }: { path: string }) => {
+      fs.writeFileSync(filePath, "png");
+    });
+    const page = { screenshot };
+
+    const helper = createScreenshotHelper(page, dir);
+    await helper("step-one");
+
+    await expect(helper("step-one")).rejects.toThrow(
+      ArtifactNameCollisionError,
+    );
+    // screenshot should not have been called a second time
+    expect(screenshot).toHaveBeenCalledOnce();
   });
 });

--- a/packages/voreux/tests/screenshot.test.ts
+++ b/packages/voreux/tests/screenshot.test.ts
@@ -65,4 +65,27 @@ describe("screenshot helpers", () => {
     // screenshot should not have been called a second time
     expect(screenshot).toHaveBeenCalledOnce();
   });
+
+  it("releases reservation on failure so the name can be retried", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "voreux-shots-"));
+    tempDirs.push(dir);
+
+    let callCount = 0;
+    const screenshot = vi.fn(async ({ path: filePath }: { path: string }) => {
+      callCount += 1;
+      // 最初の2呼び出し（fullPage あり・なし両方）は失敗させる
+      if (callCount <= 2) throw new Error("screenshot failed");
+      fs.writeFileSync(filePath, "png");
+    });
+    const page = { screenshot };
+
+    const helper = createScreenshotHelper(page, dir);
+
+    // 1回目は失敗する → 予約が解放されるはず
+    await expect(helper("step-one")).rejects.toThrow("screenshot failed");
+
+    // 2回目は成功できる（ArtifactNameCollisionError にならない）
+    const filePath = await helper("step-one");
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- `ArtifactNameCollisionError` クラスを `screenshot.ts` に追加
- `createScreenshotHelper()` にファイル存在チェックを追加 — sanitize後のパスが既に存在する場合は即座に throw
- `ArtifactNameCollisionError` / `ImageSizeMismatchError` をパブリックAPIからexport
- 衝突検出のユニットテストを追加

## Why

Issue #46 の方針に従い、サイレントな上書きや自動suffix付与ではなく、早期に失敗して呼び出し元の命名ミスを明示する。

## Notes

- run開始時のアーティファクトディレクトリクリーンアップは `stagehand.ts` に既存のため対応不要
- 衝突エラーはあくまで「同一run内での重複名」に対してのみ発火する

Closes #46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * スクリーンショット・アーティファクト名の重複検出を追加しました。既存ファイルがある場合は上書きを防ぎ明示的なエラーを返します。
  * 重複エラーとして識別可能な例外（ArtifactNameCollisionError、ImageSizeMismatchError）を公開エクスポートしました。
  * 失敗時は予約が解除され、同名での再試行が可能になりました。

* **テスト**
  * 重複検出と再試行の挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->