### PR TITLE
feat: add draft scenario support to voreux cli

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -227,6 +227,19 @@ If a suggestion is not adopted:
 - reply in the review thread
 - explain why it is not being applied in this repo context
 
+## Formatting and pre-push discipline
+
+This repo uses Biome, and formatting misses have already caused CI failures.
+Treat formatting and static checks as mandatory, not optional cleanup.
+
+Before push, and ideally before commit, run the repo checks that matter for the files you changed.
+At minimum, if you touched code or docs that Biome checks, run:
+
+- `pnpm check`
+
+If you changed package code, also run the relevant targeted tests/build steps.
+Do not rely on CI to be the first formatter feedback loop.
+
 ## Preferred outcome
 
 The best contribution to this repo is usually not the shortest code.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ pnpm test
 > 通常の公開版では `npx @uzulla/voreux init my-e2e` をそのまま使えます。
 > まだ publish していないローカル変更や未公開ブランチを試す場合は、repo からの別手順で検証してください。
 
+## Draft scenario の扱い
+
+Voreux では `*.draft.test.ts` を Draft scenario として扱います。
+
+- 通常の `voreux test` / `voreux run` では Draft は除外
+- `--include-drafts` で Draft を含めて実行
+- `--only-drafts` で Draft のみ実行
+- `VOREUX_INCLUDE_DRAFTS=1` でも opt-in 可能
+
+```bash
+voreux test
+voreux test --include-drafts
+voreux test --only-drafts
+VOREUX_INCLUDE_DRAFTS=1 voreux test
+voreux test login-flow --include-drafts
+```
+
 ## 最初のテストを書く
 
 ```ts

--- a/examples/cfe-jp/tests/cfe.draft.test.ts
+++ b/examples/cfe-jp/tests/cfe.draft.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, test } from "vitest";
+
+describe("draft sample scenario", () => {
+  test("is picked up only when drafts are included", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/voreux/README.md
+++ b/packages/voreux/README.md
@@ -25,6 +25,25 @@ pnpm add @uzulla/voreux
 - pnpm >= 10.x（推奨）または npm
 - Windows ユーザーは **WSL2** が必要です
 
+## Draft scenario の扱い
+
+Voreux では `*.draft.test.ts` を Draft scenario として扱えます。
+
+- 通常の `voreux test` / `voreux run` では Draft は除外されます
+- `--include-drafts` を付けると Draft も含めて実行されます
+- `--only-drafts` を付けると Draft だけ実行されます
+- `VOREUX_INCLUDE_DRAFTS=1` でも opt-in できます
+
+例:
+
+```bash
+voreux test
+voreux test --include-drafts
+voreux test --only-drafts
+VOREUX_INCLUDE_DRAFTS=1 voreux test
+voreux test login-flow --include-drafts
+```
+
 ## クイックスタート
 
 ```bash

--- a/packages/voreux/src/cli.ts
+++ b/packages/voreux/src/cli.ts
@@ -164,20 +164,40 @@ function matchesPattern(filePath: string, pattern?: string): boolean {
   return filePath.includes(pattern);
 }
 
+export interface ScenarioSelectionResult {
+  selected: string[];
+  excludedDrafts: string[];
+}
+
 export function resolveScenarioTargets(
   cwd: string,
   pattern: string | undefined,
   includeDrafts: boolean,
   onlyDrafts: boolean,
-): string[] {
+): ScenarioSelectionResult {
   const files = collectTestTargets(cwd);
-  return files.filter((file) => {
-    if (!matchesPattern(file, pattern)) return false;
+  const selected: string[] = [];
+  const excludedDrafts: string[] = [];
+
+  for (const file of files) {
+    if (!matchesPattern(file, pattern)) continue;
     const isDraft = isDraftScenario(file);
-    if (onlyDrafts) return isDraft;
-    if (includeDrafts) return true;
-    return !isDraft;
-  });
+    if (onlyDrafts) {
+      if (isDraft) selected.push(file);
+      continue;
+    }
+    if (includeDrafts) {
+      selected.push(file);
+      continue;
+    }
+    if (isDraft) {
+      excludedDrafts.push(file);
+      continue;
+    }
+    selected.push(file);
+  }
+
+  return { selected, excludedDrafts };
 }
 
 async function cmdInit(targetDir?: string, force?: boolean): Promise<void> {
@@ -234,14 +254,14 @@ async function cmdTest(options: {
   const onlyDrafts =
     options.onlyDrafts ?? isTruthyEnv(process.env.VOREUX_ONLY_DRAFTS);
 
-  const targets = resolveScenarioTargets(
+  const { selected, excludedDrafts } = resolveScenarioTargets(
     process.cwd(),
     options.pattern,
     includeDrafts,
     onlyDrafts,
   );
 
-  if (targets.length === 0) {
+  if (selected.length === 0) {
     const mode = onlyDrafts
       ? "draft scenarios"
       : includeDrafts
@@ -251,8 +271,13 @@ async function cmdTest(options: {
     process.exit(1);
   }
 
-  const args = ["vitest", "run", ...targets];
-  console.log(`Running vitest on ${targets.length} scenario file(s)...`);
+  const args = ["vitest", "run", ...selected];
+  console.log(`Running vitest on ${selected.length} scenario file(s)...`);
+  if (!includeDrafts && !onlyDrafts && excludedDrafts.length > 0) {
+    console.log(
+      `Excluded ${excludedDrafts.length} draft scenario file(s): ${excludedDrafts.join(", ")}`,
+    );
+  }
   const result = spawnSync("pnpm", args, {
     cwd: process.cwd(),
     stdio: "inherit",

--- a/packages/voreux/src/cli.ts
+++ b/packages/voreux/src/cli.ts
@@ -16,23 +16,32 @@ const PKG_VERSION = JSON.parse(
   ),
 ).version;
 
-const HELP_TEXT = `Voreux — Stagehand + Vitest E2E testing framework
+const HELP_TEXT = `Voreux, Stagehand + Vitest E2E testing framework
 
 Usage:
-  voreux init [dir] [--force]  Scaffold a project (default: skips existing files)
-  voreux test [pattern]         Run vitest tests (default: all)
-  voreux --help                Show this help
-  voreux --version             Show version
+  voreux init [dir] [--force]                         Scaffold a project (default: skips existing files)
+  voreux test [pattern] [--include-drafts] [--only-drafts]  Run vitest tests
+  voreux run [pattern] [--include-drafts] [--only-drafts]   Alias of test
+  voreux --help                                      Show this help
+  voreux --version                                   Show version
 
 Options:
-  --force, -f   Overwrite existing files during init
+  --force, -f         Overwrite existing files during init
+  --include-drafts    Include *.draft.test.ts in test runs
+  --only-drafts       Run only *.draft.test.ts
+
+Environment:
+  VOREUX_INCLUDE_DRAFTS=1   Include draft scenarios by default
+  VOREUX_ONLY_DRAFTS=1      Run only draft scenarios
 
 Examples:
   voreux init my-e2e
-  voreux init my-e2e --force   (overwrites any existing files)
-  cd my-e2e
-  # add OPENAI_API_KEY to .env
+  voreux init my-e2e --force
   voreux test
+  voreux test login-flow
+  voreux test --include-drafts
+  voreux test --only-drafts
+  VOREUX_INCLUDE_DRAFTS=1 voreux test
 
 For more details, see: https://github.com/uzulla/voreux`;
 
@@ -44,8 +53,8 @@ const INIT_TEMPLATE_FILES: Record<string, string> = {
       type: "module",
       private: true,
       scripts: {
-        test: "vitest run",
-        "test:self-heal": "cross-env SELF_HEAL=1 vitest run",
+        test: "voreux test",
+        "test:self-heal": "cross-env SELF_HEAL=1 voreux test",
         build: "tsc --noEmit",
       },
       dependencies: {
@@ -119,6 +128,58 @@ defineScenarioSuite({
 `,
 };
 
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function collectTestTargets(cwd: string): string[] {
+  const results: string[] = [];
+
+  function walk(dir: string): void {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+        results.push(path.relative(cwd, fullPath));
+      }
+    }
+  }
+
+  walk(cwd);
+  return results.sort();
+}
+
+function isDraftScenario(filePath: string): boolean {
+  return filePath.endsWith(".draft.test.ts");
+}
+
+function matchesPattern(filePath: string, pattern?: string): boolean {
+  if (!pattern) return true;
+  return filePath.includes(pattern);
+}
+
+export function resolveScenarioTargets(
+  cwd: string,
+  pattern: string | undefined,
+  includeDrafts: boolean,
+  onlyDrafts: boolean,
+): string[] {
+  const files = collectTestTargets(cwd);
+  return files.filter((file) => {
+    if (!matchesPattern(file, pattern)) return false;
+    const isDraft = isDraftScenario(file);
+    if (onlyDrafts) return isDraft;
+    if (includeDrafts) return true;
+    return !isDraft;
+  });
+}
+
 async function cmdInit(targetDir?: string, force?: boolean): Promise<void> {
   const resolved = targetDir ? path.resolve(targetDir) : process.cwd();
 
@@ -161,12 +222,37 @@ async function cmdInit(targetDir?: string, force?: boolean): Promise<void> {
   );
 }
 
-async function cmdTest(pattern?: string): Promise<void> {
-  const args = ["vitest", "run"];
-  if (pattern) {
-    args.push(pattern);
+async function cmdTest(options: {
+  pattern?: string;
+  includeDrafts?: boolean;
+  onlyDrafts?: boolean;
+}): Promise<void> {
+  const includeDrafts = options.onlyDrafts
+    ? false
+    : (options.includeDrafts ?? false) ||
+      isTruthyEnv(process.env.VOREUX_INCLUDE_DRAFTS);
+  const onlyDrafts =
+    options.onlyDrafts ?? isTruthyEnv(process.env.VOREUX_ONLY_DRAFTS);
+
+  const targets = resolveScenarioTargets(
+    process.cwd(),
+    options.pattern,
+    includeDrafts,
+    onlyDrafts,
+  );
+
+  if (targets.length === 0) {
+    const mode = onlyDrafts
+      ? "draft scenarios"
+      : includeDrafts
+        ? "scenarios"
+        : "non-draft scenarios";
+    console.error(`voreux test: no matching ${mode} found.`);
+    process.exit(1);
   }
-  console.log(`Running vitest...`);
+
+  const args = ["vitest", "run", ...targets];
+  console.log(`Running vitest on ${targets.length} scenario file(s)...`);
   const result = spawnSync("pnpm", args, {
     cwd: process.cwd(),
     stdio: "inherit",
@@ -183,6 +269,8 @@ async function main(): Promise<void> {
       force: { type: "boolean", short: "f" },
       help: { type: "boolean", short: "h" },
       version: { type: "boolean", short: "v" },
+      "include-drafts": { type: "boolean" },
+      "only-drafts": { type: "boolean" },
     },
     allowPositionals: true,
   });
@@ -205,7 +293,12 @@ async function main(): Promise<void> {
       break;
 
     case "test":
-      await cmdTest(rest[0]);
+    case "run":
+      await cmdTest({
+        pattern: rest[0],
+        includeDrafts: values["include-drafts"] ?? false,
+        onlyDrafts: values["only-drafts"] ?? false,
+      });
       break;
 
     case undefined:

--- a/packages/voreux/tests/cli.test.ts
+++ b/packages/voreux/tests/cli.test.ts
@@ -1,0 +1,56 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+
+function makeTempProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "voreux-cli-test-"));
+  tempDirs.push(dir);
+  fs.mkdirSync(path.join(dir, "tests"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "tests", "alpha.test.ts"), "// alpha\n");
+  fs.writeFileSync(path.join(dir, "tests", "beta.draft.test.ts"), "// beta draft\n");
+  fs.writeFileSync(path.join(dir, "tests", "gamma.test.ts"), "// gamma\n");
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("voreux cli draft scenario selection", () => {
+  it("excludes draft scenarios by default", async () => {
+    const { resolveScenarioTargets } = await import("../src/cli.js");
+    const dir = makeTempProject();
+    const targets = resolveScenarioTargets(dir, undefined, false, false);
+    expect(targets).toEqual(["tests/alpha.test.ts", "tests/gamma.test.ts"]);
+  });
+
+  it("includes draft scenarios when opted in", async () => {
+    const { resolveScenarioTargets } = await import("../src/cli.js");
+    const dir = makeTempProject();
+    const targets = resolveScenarioTargets(dir, undefined, true, false);
+    expect(targets).toEqual([
+      "tests/alpha.test.ts",
+      "tests/beta.draft.test.ts",
+      "tests/gamma.test.ts",
+    ]);
+  });
+
+  it("runs only draft scenarios when requested", async () => {
+    const { resolveScenarioTargets } = await import("../src/cli.js");
+    const dir = makeTempProject();
+    const targets = resolveScenarioTargets(dir, undefined, false, true);
+    expect(targets).toEqual(["tests/beta.draft.test.ts"]);
+  });
+
+  it("applies pattern filtering together with draft inclusion", async () => {
+    const { resolveScenarioTargets } = await import("../src/cli.js");
+    const dir = makeTempProject();
+    const targets = resolveScenarioTargets(dir, "beta", true, false);
+    expect(targets).toEqual(["tests/beta.draft.test.ts"]);
+  });
+});

--- a/packages/voreux/tests/cli.test.ts
+++ b/packages/voreux/tests/cli.test.ts
@@ -10,7 +10,10 @@ function makeTempProject(): string {
   tempDirs.push(dir);
   fs.mkdirSync(path.join(dir, "tests"), { recursive: true });
   fs.writeFileSync(path.join(dir, "tests", "alpha.test.ts"), "// alpha\n");
-  fs.writeFileSync(path.join(dir, "tests", "beta.draft.test.ts"), "// beta draft\n");
+  fs.writeFileSync(
+    path.join(dir, "tests", "beta.draft.test.ts"),
+    "// beta draft\n",
+  );
   fs.writeFileSync(path.join(dir, "tests", "gamma.test.ts"), "// gamma\n");
   return dir;
 }

--- a/packages/voreux/tests/cli.test.ts
+++ b/packages/voreux/tests/cli.test.ts
@@ -28,32 +28,39 @@ describe("voreux cli draft scenario selection", () => {
   it("excludes draft scenarios by default", async () => {
     const { resolveScenarioTargets } = await import("../src/cli.js");
     const dir = makeTempProject();
-    const targets = resolveScenarioTargets(dir, undefined, false, false);
-    expect(targets).toEqual(["tests/alpha.test.ts", "tests/gamma.test.ts"]);
+    const result = resolveScenarioTargets(dir, undefined, false, false);
+    expect(result.selected).toEqual([
+      "tests/alpha.test.ts",
+      "tests/gamma.test.ts",
+    ]);
+    expect(result.excludedDrafts).toEqual(["tests/beta.draft.test.ts"]);
   });
 
   it("includes draft scenarios when opted in", async () => {
     const { resolveScenarioTargets } = await import("../src/cli.js");
     const dir = makeTempProject();
-    const targets = resolveScenarioTargets(dir, undefined, true, false);
-    expect(targets).toEqual([
+    const result = resolveScenarioTargets(dir, undefined, true, false);
+    expect(result.selected).toEqual([
       "tests/alpha.test.ts",
       "tests/beta.draft.test.ts",
       "tests/gamma.test.ts",
     ]);
+    expect(result.excludedDrafts).toEqual([]);
   });
 
   it("runs only draft scenarios when requested", async () => {
     const { resolveScenarioTargets } = await import("../src/cli.js");
     const dir = makeTempProject();
-    const targets = resolveScenarioTargets(dir, undefined, false, true);
-    expect(targets).toEqual(["tests/beta.draft.test.ts"]);
+    const result = resolveScenarioTargets(dir, undefined, false, true);
+    expect(result.selected).toEqual(["tests/beta.draft.test.ts"]);
+    expect(result.excludedDrafts).toEqual([]);
   });
 
   it("applies pattern filtering together with draft inclusion", async () => {
     const { resolveScenarioTargets } = await import("../src/cli.js");
     const dir = makeTempProject();
-    const targets = resolveScenarioTargets(dir, "beta", true, false);
-    expect(targets).toEqual(["tests/beta.draft.test.ts"]);
+    const result = resolveScenarioTargets(dir, "beta", true, false);
+    expect(result.selected).toEqual(["tests/beta.draft.test.ts"]);
+    expect(result.excludedDrafts).toEqual([]);
   });
 });


### PR DESCRIPTION
## 概要
- `voreux test` / `voreux run` に Draft scenario の選別機能を追加
- `*.draft.test.ts` を通常実行では除外し、CLI / env で明示的に含められるようにした
- 通常実行時に、除外された Draft scenario の件数とファイル名を表示するようにした
- ドキュメントとテストを更新し、実際の CLI 実行結果も確認した
- `examples/cfe-jp/tests/` に小さな Draft sample を追加し、挙動確認に使った

## 変更内容
- `--include-drafts` を追加
- `--only-drafts` を追加
- `VOREUX_INCLUDE_DRAFTS=1` を追加
- `VOREUX_ONLY_DRAFTS=1` を追加
- Draft の表現は file naming 規約 `*.draft.test.ts` を採用
- scaffold される package scripts を `voreux test` ベースに更新
- CLI の選別ロジックに対するテストを追加
- sample file として `examples/cfe-jp/tests/cfe.draft.test.ts` を追加
- 通常実行時に Draft が除外されたら、その件数とファイル名を表示するようにした

## 実際に確認した CLI の挙動
確認に使ったファイル:
- 通常 scenario: `examples/cfe-jp/tests/cfe.test.ts`
- Draft scenario: `examples/cfe-jp/tests/cfe.draft.test.ts`

以下のログでは、レビューしやすさを優先して、INFO ログや LLM の生 response / token usage / inference time などのノイズは省いています。

### 1. 通常実行では Draft が除外され、そのことが表示される
実行コマンド:
```bash
cd examples/cfe-jp
../../packages/voreux/dist/cli.js test
```
出力:
```text
Running vitest on 1 scenario file(s)...
Excluded 1 draft scenario file(s): tests/cfe.draft.test.ts

RUN v4.0.18 /home/zishida/dev/voreux/examples/cfe-jp

✓ tests/cfe.test.ts > cfe.jp E2E > Navigate to page 2110ms
✓ tests/cfe.test.ts > cfe.jp E2E > Extract profile 14251ms
✓ tests/cfe.test.ts > cfe.jp E2E > Extract books 6585ms
✓ tests/cfe.test.ts > cfe.jp E2E > Observe links 5064ms
✓ tests/cfe.test.ts > cfe.jp E2E > Click GitHub link 5211ms

Test Files 1 passed (1)
Tests 5 passed (5)
Start at 08:53:19
Duration 34.89s (transform 81ms, setup 0ms, import 511ms, tests 34.29s, environment 0ms)
```

### 2. `--include-drafts` を付けると通常 + Draft の両方が対象になる
実行コマンド:
```bash
cd examples/cfe-jp
../../packages/voreux/dist/cli.js test --include-drafts
```
出力:
```text
Running vitest on 2 scenario file(s)...

RUN v4.0.18 /home/zishida/dev/voreux/examples/cfe-jp

✓ tests/cfe.draft.test.ts > draft sample scenario > is picked up only when drafts are included 1ms
✓ tests/cfe.test.ts > cfe.jp E2E > Navigate to page 1252ms
✓ tests/cfe.test.ts > cfe.jp E2E > Extract profile 4205ms
✓ tests/cfe.test.ts > cfe.jp E2E > Extract books 13315ms
✓ tests/cfe.test.ts > cfe.jp E2E > Observe links 5251ms
✓ tests/cfe.test.ts > cfe.jp E2E > Click GitHub link 8797ms

Test Files 2 passed (2)
Tests 6 passed (6)
Start at 08:53:54
Duration 33.37s (transform 93ms, setup 0ms, import 505ms, tests 32.76s, environment 0ms)
```

### 3. `--only-drafts` を付けると Draft だけ実行される
実行コマンド:
```bash
cd examples/cfe-jp
../../packages/voreux/dist/cli.js test --only-drafts
```
出力:
```text
Running vitest on 1 scenario file(s)...

RUN v4.0.18 /home/zishida/dev/voreux/examples/cfe-jp

✓ tests/cfe.draft.test.ts > draft sample scenario > is picked up only when drafts are included 1ms

Test Files 1 passed (1)
Tests 1 passed (1)
Start at 08:54:27
Duration 120ms (transform 19ms, setup 0ms, import 28ms, tests 2ms, environment 0ms)
```

## 確認したこと
- `pnpm check`
- `pnpm --filter @uzulla/voreux test`
- `pnpm --filter @uzulla/voreux build`
- `examples/cfe-jp` での手動 CLI 実行
  - `../../packages/voreux/dist/cli.js test`
  - `../../packages/voreux/dist/cli.js test --include-drafts`
  - `../../packages/voreux/dist/cli.js test --only-drafts`
- `coderabbit review --plain`

## 補足
- 除外 Draft の表示は、Vitest ランナー本体を大きく改造せず、CLI の file selection 時点で実装しています
- 今回は issue #57 のスコープに合わせて、まず naming convention ベースの Draft support を入れる実装に寄せました

Closes #57
