### PR TITLE
feat: expose recorder scaffold through the main voreux CLI

### DIFF
--- a/docs/devtools-recorder-json-operations.md
+++ b/docs/devtools-recorder-json-operations.md
@@ -1,0 +1,150 @@
+# DevTools Recorder JSON operations support
+
+このドキュメントは、`packages/voreux/src/scaffold-generation/from-devtools-recorder-json.ts` が
+Chrome DevTools Recorder / Puppeteer Replay 由来の JSON でどの operation (`step.type`) を扱えるかを整理したものです。
+
+## 前提
+
+- 入力 JSON は `title` と `steps` を持つ object を想定します
+- `steps` は少なくとも 1 件必要です
+- 少なくとも 1 件の `navigate` step が必要です
+- selector を使う step は、最終的に `document.querySelector()` 互換の selector を 1 つ選べる必要があります
+  - `aria/...` / `pierce/...` / `xpath/...` は一部変換されます
+  - CSS selector を 1 つも選べない場合は失敗します
+
+## 現在サポートしている operation 一覧
+
+現在の実装で scaffold 生成に対応している `step.type` は次のとおりです。
+
+- `setViewport`
+- `navigate`
+- `click`
+- `change`
+- `type`
+- `select`
+- `waitForElement`
+
+## operation ごとの変換内容
+
+### `setViewport`
+- 必須フィールド: `width`, `height`
+- 生成内容:
+  - `ctx.page.setViewportSize({ width, height })`
+- 備考:
+  - `deviceScaleFactor`, `isMobile`, `hasTouch`, `isLandscape` は現在 scaffold 生成には未反映
+
+### `navigate`
+- 必須フィールド: `url`
+- 生成内容:
+  - `ctx.page.goto(url)`
+  - `ctx.page.waitForLoadState("networkidle")`
+  - screenshot
+- 備考:
+  - 最初の `navigate` の `url` を `originUrl` として採用
+
+### `click`
+- 必須フィールド: `selectors`
+- 生成内容:
+  - `waitForSelector`
+  - `page.evaluate(... element.click())`
+  - `waitForLoadState("networkidle")`
+  - screenshot
+- 備考:
+  - recorded selector 群はコメントとして残す
+
+### `change`
+- 必須フィールド: `selectors` と `value` または `text`
+- 生成内容:
+  - `input` / `textarea` に対して value を代入
+  - `input` / `change` event を dispatch
+  - screenshot
+
+### `type`
+- 現状の扱い:
+  - `change` と同じ処理として扱う互換入力
+- 必須フィールド:
+  - `selectors` と `value` または `text`
+- 備考:
+  - 逐次 key input の再現ではなく、最終値を入れる scaffold を生成
+
+### `select`
+- 必須フィールド: `selectors`, `value`
+- 生成内容:
+  - `HTMLSelectElement.value` の設定
+  - `input` / `change` event を dispatch
+  - screenshot
+
+### `waitForElement`
+- 必須フィールド: `selectors`
+- 生成内容:
+  - `waitForSelector`
+  - screenshot
+- 備考:
+  - assertion というより最小限の wait scaffold として出力
+  - `operator`, `count`, `visible`, `attributes`, `properties` は現在未反映
+
+## JSON でありえる operation の一覧と対応状況
+
+以下は Puppeteer Replay schema の `Schema.Step` / `Schema.UserStep` / `Schema.AssertionStep` を基準にした一覧です。
+
+| operation | 現在の対応 | 備考 |
+|---|---|---|
+| `setViewport` | 対応 | width/height を scaffold に反映 |
+| `navigate` | 対応 | originUrl 決定にも使用 |
+| `click` | 対応 | selector ベースの click scaffold を生成 |
+| `change` | 対応 | input/textarea への値設定 |
+| `select` | 対応 | select 要素への値設定 |
+| `waitForElement` | 対応 | 単純な wait scaffold として対応 |
+| `type` | 対応（互換入力） | schema の主要一覧には見えないが実装では受理 |
+| `hover` | 非対応 | `Unsupported DevTools Recorder step type` |
+| `close` | 非対応 | 同上 |
+| `doubleClick` | 非対応 | テストで unsupported 扱いを確認済み |
+| `emulateNetworkConditions` | 非対応 | 同上 |
+| `keyDown` | 非対応 | 同上 |
+| `keyUp` | 非対応 | 同上 |
+| `scroll` | 非対応 | page / element scroll とも未対応 |
+| `waitForExpression` | 非対応 | assertion 系だが未対応 |
+| `customStep` | 非対応 | custom step 未対応 |
+
+## 実装上の補足
+
+### unsupported operation の挙動
+
+未対応 operation が来た場合は、現在は黙ってスキップせず失敗します。
+
+- 例: `Unsupported DevTools Recorder step type: doubleClick`
+
+これは不完全な scaffold を silently 生成しないための挙動です。
+
+### selector 変換の現在仕様
+
+以下は一定の変換を行います。
+
+- `aria/...` → `[aria-label="..."]`
+- `xpath/...` / `xpath//...` → `xpath=...`
+- `pierce/...` → prefix を外す
+
+ただし scaffold 内では `document.querySelector()` を使う step もあるため、
+実質的には CSS selector が 1 つ見つかるケースを最も安全な前提にしています。
+
+### 現在未反映の代表的な JSON フィールド
+
+step 自体は受け付けても、次のような追加フィールドは今の scaffold では十分に使っていません。
+
+- `assertedEvents`
+- `timeout`
+- `frame`
+- `target`
+- `offsetX`, `offsetY`
+- `deviceType`
+- `button`
+- `operator`, `count`, `visible`, `attributes`, `properties`
+- `deviceScaleFactor`, `isMobile`, `hasTouch`, `isLandscape`
+
+## 参考
+
+- 実装: `packages/voreux/src/scaffold-generation/from-devtools-recorder-json.ts`
+- テスト: `packages/voreux/tests/scaffold-generation-from-devtools-recorder-json.test.ts`
+- 参考 schema: Puppeteer Replay `Schema.UserFlow` / `Schema.Step`
+- Chrome DevTools Recorder reference: <https://developer.chrome.com/docs/devtools/recorder/reference>
+- Puppeteer Replay schema docs: <https://github.com/puppeteer/replay/blob/main/docs/api/modules/Schema.md>

--- a/docs/devtools-recorder-json-operations.md
+++ b/docs/devtools-recorder-json-operations.md
@@ -3,6 +3,29 @@
 このドキュメントは、`packages/voreux/src/scaffold-generation/from-devtools-recorder-json.ts` が
 Chrome DevTools Recorder / Puppeteer Replay 由来の JSON でどの operation (`step.type`) を扱えるかを整理したものです。
 
+## 対応表
+
+以下は Puppeteer Replay schema の `Schema.Step` / `Schema.UserStep` / `Schema.AssertionStep` を基準にした一覧です。
+
+| operation | 現在の対応 | 備考 |
+|---|---|---|
+| `setViewport` | 対応 | width/height を scaffold に反映 |
+| `navigate` | 対応 | originUrl 決定にも使用 |
+| `click` | 対応 | selector ベースの click scaffold を生成 |
+| `change` | 対応 | input/textarea への値設定 |
+| `select` | 対応 | select 要素への値設定 |
+| `waitForElement` | 対応 | 単純な wait scaffold として対応 |
+| `type` | 対応（互換入力） | schema の主要一覧には見えないが実装では受理 |
+| `hover` | 非対応 | `Unsupported DevTools Recorder step type` |
+| `close` | 非対応 | 同上 |
+| `doubleClick` | 非対応 | テストで unsupported 扱いを確認済み |
+| `emulateNetworkConditions` | 非対応 | 同上 |
+| `keyDown` | 非対応 | 同上 |
+| `keyUp` | 非対応 | 同上 |
+| `scroll` | 非対応 | page / element scroll とも未対応 |
+| `waitForExpression` | 非対応 | assertion 系だが未対応 |
+| `customStep` | 非対応 | custom step 未対応 |
+
 ## 前提
 
 - 入力 JSON は `title` と `steps` を持つ object を想定します
@@ -82,29 +105,6 @@ Chrome DevTools Recorder / Puppeteer Replay 由来の JSON でどの operation (
 - 備考:
   - assertion というより最小限の wait scaffold として出力
   - `operator`, `count`, `visible`, `attributes`, `properties` は現在未反映
-
-## JSON でありえる operation の一覧と対応状況
-
-以下は Puppeteer Replay schema の `Schema.Step` / `Schema.UserStep` / `Schema.AssertionStep` を基準にした一覧です。
-
-| operation | 現在の対応 | 備考 |
-|---|---|---|
-| `setViewport` | 対応 | width/height を scaffold に反映 |
-| `navigate` | 対応 | originUrl 決定にも使用 |
-| `click` | 対応 | selector ベースの click scaffold を生成 |
-| `change` | 対応 | input/textarea への値設定 |
-| `select` | 対応 | select 要素への値設定 |
-| `waitForElement` | 対応 | 単純な wait scaffold として対応 |
-| `type` | 対応（互換入力） | schema の主要一覧には見えないが実装では受理 |
-| `hover` | 非対応 | `Unsupported DevTools Recorder step type` |
-| `close` | 非対応 | 同上 |
-| `doubleClick` | 非対応 | テストで unsupported 扱いを確認済み |
-| `emulateNetworkConditions` | 非対応 | 同上 |
-| `keyDown` | 非対応 | 同上 |
-| `keyUp` | 非対応 | 同上 |
-| `scroll` | 非対応 | page / element scroll とも未対応 |
-| `waitForExpression` | 非対応 | assertion 系だが未対応 |
-| `customStep` | 非対応 | custom step 未対応 |
 
 ## 実装上の補足
 

--- a/docs/devtools-recorder-json-operations.md
+++ b/docs/devtools-recorder-json-operations.md
@@ -3,6 +3,17 @@
 このドキュメントは、`packages/voreux/src/scaffold-generation/from-devtools-recorder-json.ts` が
 Chrome DevTools Recorder / Puppeteer Replay 由来の JSON でどの operation (`step.type`) を扱えるかを整理したものです。
 
+JSON フォーマット仕様の参照元としては、次を起点に見るのが分かりやすいです。
+
+- Chrome DevTools Recorder reference
+  - <https://developer.chrome.com/docs/devtools/recorder/reference>
+- Puppeteer Replay schema docs
+  - <https://github.com/puppeteer/replay/blob/main/docs/api/modules/Schema.md>
+- Puppeteer Replay `UserFlow` interface
+  - <https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.UserFlow.md>
+
+※ DevTools Recorder の JSON は実質的に Puppeteer Replay schema を前提に見たほうが追いやすいです。
+
 ## 対応表
 
 以下は Puppeteer Replay schema の `Schema.Step` / `Schema.UserStep` / `Schema.AssertionStep` を基準にした一覧です。
@@ -148,3 +159,4 @@ step 自体は受け付けても、次のような追加フィールドは今の
 - 参考 schema: Puppeteer Replay `Schema.UserFlow` / `Schema.Step`
 - Chrome DevTools Recorder reference: <https://developer.chrome.com/docs/devtools/recorder/reference>
 - Puppeteer Replay schema docs: <https://github.com/puppeteer/replay/blob/main/docs/api/modules/Schema.md>
+- Puppeteer Replay `UserFlow` interface: <https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.UserFlow.md>

--- a/examples/devtools-recorder-cfe-jp/README.md
+++ b/examples/devtools-recorder-cfe-jp/README.md
@@ -32,7 +32,7 @@
 PoC ツールは標準入力またはファイル入力から JSON を受け取り、標準出力に Draft scenario を出します。
 
 ```bash
-node ./packages/voreux/dist/scaffold-generation/from-devtools-recorder-json-cli.js \
+node ./packages/voreux/dist/cli.js scaffold from devtools-recorder-json \
   ./examples/devtools-recorder-cfe-jp/recorder/cfe-github-link.json \
   > ./examples/devtools-recorder-cfe-jp/tests/cfe-github-link.generated.draft.test.ts
 ```
@@ -41,9 +41,11 @@ node ./packages/voreux/dist/scaffold-generation/from-devtools-recorder-json-cli.
 
 ```bash
 cat ./examples/devtools-recorder-cfe-jp/recorder/cfe-github-link.json \
-  | node ./packages/voreux/dist/scaffold-generation/from-devtools-recorder-json-cli.js \
+  | node ./packages/voreux/dist/cli.js scaffold from devtools-recorder-json \
   > ./examples/devtools-recorder-cfe-jp/tests/cfe-github-link.generated.draft.test.ts
 ```
+
+互換用の個別 CLI (`from-devtools-recorder-json-cli.js`) も引き続き利用できます。
 
 ## この後に人間がやること
 

--- a/examples/devtools-recorder-cfe-jp/README.md
+++ b/examples/devtools-recorder-cfe-jp/README.md
@@ -32,7 +32,7 @@
 PoC ツールは標準入力またはファイル入力から JSON を受け取り、標準出力に Draft scenario を出します。
 
 ```bash
-node ./packages/voreux/dist/cli.js scaffold from devtools-recorder-json \
+voreux scaffold from devtools-recorder-json \
   ./examples/devtools-recorder-cfe-jp/recorder/cfe-github-link.json \
   > ./examples/devtools-recorder-cfe-jp/tests/cfe-github-link.generated.draft.test.ts
 ```
@@ -41,11 +41,13 @@ node ./packages/voreux/dist/cli.js scaffold from devtools-recorder-json \
 
 ```bash
 cat ./examples/devtools-recorder-cfe-jp/recorder/cfe-github-link.json \
-  | node ./packages/voreux/dist/cli.js scaffold from devtools-recorder-json \
+  | voreux scaffold from devtools-recorder-json \
   > ./examples/devtools-recorder-cfe-jp/tests/cfe-github-link.generated.draft.test.ts
 ```
 
-互換用の個別 CLI (`from-devtools-recorder-json-cli.js`) も引き続き利用できます。
+`[file]` を省略した場合は標準入力が必要です。入力なしの TTY 実行は usage error になります。
+
+互換用の個別 CLI (`from-devtools-recorder-json-cli.js`) や `node ./packages/voreux/dist/cli.js ...` も引き続き利用できます。
 
 ## この後に人間がやること
 

--- a/packages/voreux/README.md
+++ b/packages/voreux/README.md
@@ -66,6 +66,14 @@ Recorder JSON には主に操作手順が入っており、
 現在の DevTools Recorder JSON entrypoint の使い方:
 
 ```bash
+voreux scaffold from devtools-recorder-json recording.json > scaffold.draft.test.ts
+# または
+cat recording.json | voreux scaffold from devtools-recorder-json > scaffold.draft.test.ts
+```
+
+互換用の個別バイナリも残しています:
+
+```bash
 voreux-scaffold-from-devtools-recorder-json < recording.json > scaffold.draft.test.ts
 # または
 node ./dist/scaffold-generation/from-devtools-recorder-json-cli.js recording.json > scaffold.draft.test.ts

--- a/packages/voreux/README.md
+++ b/packages/voreux/README.md
@@ -71,6 +71,9 @@ voreux scaffold from devtools-recorder-json recording.json > scaffold.draft.test
 cat recording.json | voreux scaffold from devtools-recorder-json > scaffold.draft.test.ts
 ```
 
+`[file]` を省略した場合は、標準入力から JSON が渡される前提です。
+TTY から入力なしで実行した場合は、入力待ちで止まらないよう usage error を返します。
+
 互換用の個別バイナリも残しています:
 
 ```bash

--- a/packages/voreux/src/cli.ts
+++ b/packages/voreux/src/cli.ts
@@ -2,8 +2,17 @@
 import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
+import {
+  stderr as errorOutput,
+  stdin as input,
+  stdout as output,
+} from "process";
 import { fileURLToPath } from "url";
 import { parseArgs } from "util";
+import {
+  generateDraftScenarioFromRecorder,
+  parseDevToolsRecorderJson,
+} from "./scaffold-generation/from-devtools-recorder-json.js";
 
 const PKG_VERSION = JSON.parse(
   fs.readFileSync(
@@ -19,11 +28,12 @@ const PKG_VERSION = JSON.parse(
 const HELP_TEXT = `Voreux, Stagehand + Vitest E2E testing framework
 
 Usage:
-  voreux init [dir] [--force]                         Scaffold a project (default: skips existing files)
+  voreux init [dir] [--force]                                Scaffold a project (default: skips existing files)
   voreux test [pattern] [--include-drafts] [--only-drafts]  Run vitest tests
   voreux run [pattern] [--include-drafts] [--only-drafts]   Alias of test
-  voreux --help                                      Show this help
-  voreux --version                                   Show version
+  voreux scaffold from devtools-recorder-json [file]        Generate a draft scenario from Recorder JSON
+  voreux --help                                             Show this help
+  voreux --version                                          Show version
 
 Options:
   --force, -f         Overwrite existing files during init
@@ -42,6 +52,8 @@ Examples:
   voreux test --include-drafts
   voreux test --only-drafts
   VOREUX_INCLUDE_DRAFTS=1 voreux test
+  voreux scaffold from devtools-recorder-json recording.json > scaffold.draft.test.ts
+  cat recording.json | voreux scaffold from devtools-recorder-json > scaffold.draft.test.ts
 
 For more details, see: https://github.com/uzulla/voreux`;
 
@@ -242,6 +254,21 @@ async function cmdInit(targetDir?: string, force?: boolean): Promise<void> {
   );
 }
 
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of input) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function generateDraftScenarioFromRecorderSource(
+  source: string,
+): Promise<string> {
+  const parsed = parseDevToolsRecorderJson(source);
+  return generateDraftScenarioFromRecorder(parsed);
+}
+
 async function cmdTest(options: {
   pattern?: string;
   includeDrafts?: boolean;
@@ -288,6 +315,33 @@ async function cmdTest(options: {
   }
 }
 
+async function cmdScaffold(rest: string[]): Promise<void> {
+  if (
+    rest.length < 2 ||
+    rest[0] !== "from" ||
+    rest[1] !== "devtools-recorder-json"
+  ) {
+    errorOutput.write(
+      "voreux scaffold: expected `voreux scaffold from devtools-recorder-json [file]`\n",
+    );
+    process.exit(1);
+  }
+
+  if (rest.length > 3) {
+    errorOutput.write(
+      "voreux scaffold: too many arguments for `devtools-recorder-json`\n",
+    );
+    process.exit(1);
+  }
+
+  const sourcePath = rest[2];
+  const source = sourcePath
+    ? fs.readFileSync(sourcePath, "utf8")
+    : await readStdin();
+  const generated = await generateDraftScenarioFromRecorderSource(source);
+  output.write(generated);
+}
+
 async function main(): Promise<void> {
   const { values, positionals } = parseArgs({
     options: {
@@ -324,6 +378,10 @@ async function main(): Promise<void> {
         includeDrafts: values["include-drafts"] ?? false,
         onlyDrafts: values["only-drafts"] ?? false,
       });
+      break;
+
+    case "scaffold":
+      await cmdScaffold(rest);
       break;
 
     case undefined:

--- a/packages/voreux/src/cli.ts
+++ b/packages/voreux/src/cli.ts
@@ -335,6 +335,13 @@ async function cmdScaffold(rest: string[]): Promise<void> {
   }
 
   const sourcePath = rest[2];
+  if (!sourcePath && input.isTTY) {
+    errorOutput.write(
+      "voreux scaffold: no input. pass [file] or pipe JSON via stdin.\n",
+    );
+    process.exit(1);
+  }
+
   const source = sourcePath
     ? fs.readFileSync(sourcePath, "utf8")
     : await readStdin();
@@ -395,8 +402,14 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  const message = err instanceof Error ? err.message : String(err);
-  console.error(`voreux: fatal error: ${message}`);
-  process.exit(1);
-});
+const isDirectCliInvocation =
+  process.argv[1] != null &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectCliInvocation) {
+  main().catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`voreux: fatal error: ${message}`);
+    process.exit(1);
+  });
+}

--- a/packages/voreux/tests/cli.test.ts
+++ b/packages/voreux/tests/cli.test.ts
@@ -78,4 +78,19 @@ describe("voreux cli", () => {
     expect(generated).toContain('suiteName: "Recorder import"');
     expect(generated).toContain('await ctx.page.goto("https://example.com/")');
   });
+
+  it("throws on unsupported recorder steps", async () => {
+    const { generateDraftScenarioFromRecorderSource } = await import(
+      "../src/cli.js"
+    );
+
+    await expect(
+      generateDraftScenarioFromRecorderSource(
+        JSON.stringify({
+          title: "Unsupported",
+          steps: [{ type: "setViewport", width: 1280, height: 720 }],
+        }),
+      ),
+    ).rejects.toThrow();
+  });
 });

--- a/packages/voreux/tests/cli.test.ts
+++ b/packages/voreux/tests/cli.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
   }
 });
 
-describe("voreux cli draft scenario selection", () => {
+describe("voreux cli", () => {
   it("excludes draft scenarios by default", async () => {
     const { resolveScenarioTargets } = await import("../src/cli.js");
     const dir = makeTempProject();
@@ -62,5 +62,20 @@ describe("voreux cli draft scenario selection", () => {
     const result = resolveScenarioTargets(dir, "beta", true, false);
     expect(result.selected).toEqual(["tests/beta.draft.test.ts"]);
     expect(result.excludedDrafts).toEqual([]);
+  });
+
+  it("generates recorder scaffolds through the main cli module helper", async () => {
+    const { generateDraftScenarioFromRecorderSource } = await import(
+      "../src/cli.js"
+    );
+    const generated = await generateDraftScenarioFromRecorderSource(
+      JSON.stringify({
+        title: "Recorder import",
+        steps: [{ type: "navigate", url: "https://example.com/" }],
+      }),
+    );
+
+    expect(generated).toContain('suiteName: "Recorder import"');
+    expect(generated).toContain('await ctx.page.goto("https://example.com/")');
   });
 });


### PR DESCRIPTION
## Summary
- add `voreux scaffold from devtools-recorder-json [file]` to the main CLI
- reuse the existing recorder JSON parser/generator from `cli.ts`
- update docs/examples to prefer the main CLI while keeping the dedicated compatibility binary documented

## Testing
- `pnpm check`
- `pnpm --filter @uzulla/voreux test`
- `pnpm --filter @uzulla/voreux build`

Fixes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Chrome DevTools Recorder JSON から雛形テストシナリオを生成する CLI サブコマンドを追加（ファイル指定・パイプ入力対応、TTY 無入力時は usage エラーを返す挙動明記）。

* **ドキュメント**
  * README と新規ドキュメントに生成手順、パイプ例、入力前提・対応/非対応ステップ一覧、互換コマンド注記を追記。

* **公開API**
  * JSON 文字列から雛形を生成する公開ヘルパーを追加。

* **テスト**
  * 生成結果の内容と非対応ステップでのエラー挙動を検証するテストを追加。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uzulla/voreux/pull/62)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->