### PR TITLE
feat: add preview selection helper

### DIFF
--- a/examples/shadcn-component/tests/button-group-helpers.ts
+++ b/examples/shadcn-component/tests/button-group-helpers.ts
@@ -10,19 +10,9 @@ import {
  * docs ページ内には複数サンプルがあるため、最上部 preview の button-group を対象に固定する。
  */
 async function findButtonGroupPreviewIndex(page: any): Promise<number> {
-  return findPreviewIndex(page, (preview) => {
-    const group = preview.querySelector(
-      '[data-slot="button-group"]',
-    ) as HTMLElement | null;
-    if (!group) return false;
-    const texts = Array.from(group.querySelectorAll("button")).map((el) =>
-      (el.textContent || "").trim(),
-    );
-    return (
-      texts.includes("Archive") &&
-      texts.includes("Report") &&
-      texts.includes("Snooze")
-    );
+  return findPreviewIndex(page, {
+    targetSelector: '[data-slot="button-group"]',
+    buttonTextsAll: ["Archive", "Report", "Snooze"],
   });
 }
 
@@ -148,24 +138,28 @@ export async function getButtonVisualState(
   color: string;
   matchesHover: boolean;
 }> {
-  return page.evaluate((targetLabel: string) => {
-    const preview = document.querySelector(
-      '[data-slot="preview"]',
-    ) as HTMLElement | null;
-    const group = preview?.querySelector(
-      '[data-slot="button-group"]',
-    ) as HTMLElement | null;
-    const button = Array.from(group?.querySelectorAll("button") ?? []).find(
-      (el) => (el.textContent || "").trim() === targetLabel,
-    ) as HTMLElement | undefined;
-    if (!button) throw new Error(`button not found: ${targetLabel}`);
-    const cs = getComputedStyle(button);
-    return {
-      backgroundColor: cs.backgroundColor,
-      color: cs.color,
-      matchesHover: button.matches(":hover"),
-    };
-  }, label);
+  const previewIndex = await findButtonGroupPreviewIndex(page);
+  return page.evaluate(
+    (args: { previewIndex: number; targetLabel: string }) => {
+      const preview = document.querySelectorAll('[data-slot="preview"]')[
+        args.previewIndex
+      ] as HTMLElement | undefined;
+      const group = preview?.querySelector(
+        '[data-slot="button-group"]',
+      ) as HTMLElement | null;
+      const button = Array.from(group?.querySelectorAll("button") ?? []).find(
+        (el) => (el.textContent || "").trim() === args.targetLabel,
+      ) as HTMLElement | undefined;
+      if (!button) throw new Error(`button not found: ${args.targetLabel}`);
+      const cs = getComputedStyle(button);
+      return {
+        backgroundColor: cs.backgroundColor,
+        color: cs.color,
+        matchesHover: button.matches(":hover"),
+      };
+    },
+    { previewIndex, targetLabel: label },
+  );
 }
 
 export async function waitForMenuVisible(page: any): Promise<void> {

--- a/examples/shadcn-component/tests/button-group-helpers.ts
+++ b/examples/shadcn-component/tests/button-group-helpers.ts
@@ -1,4 +1,5 @@
 import {
+  findPreviewIndex,
   getCenterPoint,
   humanHover,
   type TestContext,
@@ -8,6 +9,23 @@ import {
 /**
  * docs ページ内には複数サンプルがあるため、最上部 preview の button-group を対象に固定する。
  */
+async function findButtonGroupPreviewIndex(page: any): Promise<number> {
+  return findPreviewIndex(page, (preview) => {
+    const group = preview.querySelector(
+      '[data-slot="button-group"]',
+    ) as HTMLElement | null;
+    if (!group) return false;
+    const texts = Array.from(group.querySelectorAll("button")).map((el) =>
+      (el.textContent || "").trim(),
+    );
+    return (
+      texts.includes("Archive") &&
+      texts.includes("Report") &&
+      texts.includes("Snooze")
+    );
+  });
+}
+
 export async function getPrimaryButtonGroupButtons(page: any): Promise<
   Array<{
     text: string;
@@ -19,24 +37,11 @@ export async function getPrimaryButtonGroupButtons(page: any): Promise<
     ariaControls: string | null;
   }>
 > {
-  const buttons = await page.evaluate(() => {
-    const previews = Array.from(
-      document.querySelectorAll('[data-slot="preview"]'),
-    ) as HTMLElement[];
-    const preview = previews.find((candidate) => {
-      const group = candidate.querySelector(
-        '[data-slot="button-group"]',
-      ) as HTMLElement | null;
-      if (!group) return false;
-      const texts = Array.from(group.querySelectorAll("button")).map((el) =>
-        (el.textContent || "").trim(),
-      );
-      return (
-        texts.includes("Archive") &&
-        texts.includes("Report") &&
-        texts.includes("Snooze")
-      );
-    }) as HTMLElement | undefined;
+  const pi = await findButtonGroupPreviewIndex(page);
+  const buttons = await page.evaluate((previewIndex: number) => {
+    const preview = document.querySelectorAll('[data-slot="preview"]')[
+      previewIndex
+    ] as HTMLElement | undefined;
     const group = preview?.querySelector(
       '[data-slot="button-group"]',
     ) as HTMLElement | null;
@@ -54,7 +59,7 @@ export async function getPrimaryButtonGroupButtons(page: any): Promise<
         ariaControls: target.getAttribute("aria-controls"),
       };
     });
-  });
+  }, pi);
   return buttons;
 }
 
@@ -73,51 +78,43 @@ export async function hoverButtonByText(
   label: string,
 ): Promise<void> {
   const page = ctx.page;
+  const pi = await findButtonGroupPreviewIndex(page);
   const point = await getButtonClickPoint(page, (text) => text === label);
   await humanHover(ctx, point, {
     label: `Hover: ${label}`,
     reinforce: async () => {
-      await page.evaluate((targetLabel: string) => {
-        const previews = Array.from(
-          document.querySelectorAll('[data-slot="preview"]'),
-        ) as HTMLElement[];
-        const preview = previews.find((candidate) => {
-          const group = candidate.querySelector(
+      await page.evaluate(
+        (args: { previewIndex: number; targetLabel: string }) => {
+          const preview = document.querySelectorAll('[data-slot="preview"]')[
+            args.previewIndex
+          ] as HTMLElement | undefined;
+          const group = preview?.querySelector(
             '[data-slot="button-group"]',
           ) as HTMLElement | null;
-          if (!group) return false;
-          const texts = Array.from(group.querySelectorAll("button")).map((el) =>
-            (el.textContent || "").trim(),
-          );
-          return (
-            texts.includes("Archive") &&
-            texts.includes("Report") &&
-            texts.includes("Snooze")
-          );
-        });
-        const group = preview?.querySelector(
-          '[data-slot="button-group"]',
-        ) as HTMLElement | null;
-        const button = Array.from(group?.querySelectorAll("button") ?? []).find(
-          (el) => (el.textContent || "").trim() === targetLabel,
-        ) as HTMLElement | undefined;
-        if (!button) return;
-        for (const type of [
-          "pointerenter",
-          "mouseenter",
-          "mouseover",
-          "pointermove",
-          "mousemove",
-        ]) {
-          button.dispatchEvent(
-            new MouseEvent(type, {
-              bubbles: true,
-              cancelable: true,
-              view: window,
-            }),
-          );
-        }
-      }, label);
+          const button = Array.from(
+            group?.querySelectorAll("button") ?? [],
+          ).find((el) => (el.textContent || "").trim() === args.targetLabel) as
+            | HTMLElement
+            | undefined;
+          if (!button) return;
+          for (const type of [
+            "pointerenter",
+            "mouseenter",
+            "mouseover",
+            "pointermove",
+            "mousemove",
+          ]) {
+            button.dispatchEvent(
+              new MouseEvent(type, {
+                bubbles: true,
+                cancelable: true,
+                view: window,
+              }),
+            );
+          }
+        },
+        { previewIndex: pi, targetLabel: label },
+      );
     },
   });
 }

--- a/examples/shadcn-component/tests/calendar-helpers.ts
+++ b/examples/shadcn-component/tests/calendar-helpers.ts
@@ -4,6 +4,7 @@ import {
   clearPointerHover,
   createArtifactPath,
   ensureDir,
+  findPreviewIndex,
   findSelectByOptionValues,
   screenshotClipAroundBox,
 } from "@uzulla/voreux";
@@ -29,36 +30,20 @@ ensureDir(SHOTS_DIR);
 export async function getTargetCalendarPreview(
   page: any,
 ): Promise<{ previewIndex: number }> {
-  const result = await page.evaluate(() => {
-    const previews = Array.from(
-      document.querySelectorAll('[data-slot="preview"]'),
-    );
-    for (let pi = 0; pi < previews.length; pi++) {
-      const cal = previews[pi].querySelector(
-        '[data-slot="calendar"][data-mode="single"]',
-      ) as HTMLElement | null;
-      if (!cal) continue;
+  const previewIndex = await findPreviewIndex(page, (preview) => {
+    const cal = preview.querySelector(
+      '[data-slot="calendar"][data-mode="single"]',
+    ) as HTMLElement | null;
+    if (!cal) return false;
 
-      // single-date calendar は month grid が 1 つだけ
-      const grids = cal.querySelectorAll('table[role="grid"]');
-      if (grids.length !== 1) continue;
+    const grids = cal.querySelectorAll('table[role="grid"]');
+    if (grids.length !== 1) return false;
 
-      // basic demo は captionLayout="dropdown" で select を持つ
-      const selects = cal.querySelectorAll("select");
-      if (selects.length < 2) continue;
-
-      return { previewIndex: pi };
-    }
-    return null;
+    const selects = cal.querySelectorAll("select");
+    return selects.length >= 2;
   });
-  if (!result) {
-    throw new Error(
-      "basic single-date calendar preview not found — " +
-        'expected [data-slot="calendar"][data-mode="single"] ' +
-        "with 1 grid table and dropdown selects",
-    );
-  }
-  return result;
+
+  return { previewIndex };
 }
 
 /**

--- a/examples/shadcn-component/tests/calendar-helpers.ts
+++ b/examples/shadcn-component/tests/calendar-helpers.ts
@@ -30,17 +30,12 @@ ensureDir(SHOTS_DIR);
 export async function getTargetCalendarPreview(
   page: any,
 ): Promise<{ previewIndex: number }> {
-  const previewIndex = await findPreviewIndex(page, (preview) => {
-    const cal = preview.querySelector(
-      '[data-slot="calendar"][data-mode="single"]',
-    ) as HTMLElement | null;
-    if (!cal) return false;
-
-    const grids = cal.querySelectorAll('table[role="grid"]');
-    if (grids.length !== 1) return false;
-
-    const selects = cal.querySelectorAll("select");
-    return selects.length >= 2;
+  const previewIndex = await findPreviewIndex(page, {
+    targetSelector: '[data-slot="calendar"][data-mode="single"]',
+    selectorCounts: [
+      { selector: 'table[role="grid"]', equals: 1 },
+      { selector: "select", atLeast: 2 },
+    ],
   });
 
   return { previewIndex };

--- a/packages/voreux/src/browser-grounded.ts
+++ b/packages/voreux/src/browser-grounded.ts
@@ -220,6 +220,53 @@ export function createArtifactPath(dir: string, name: string): string {
   return path.join(dir, `${sanitizeArtifactName(name)}.png`);
 }
 
+/**
+ * Find the 0-based index of the first `[data-slot="preview"]` element
+ * matching the given criteria.
+ *
+ * `match` may be either:
+ * - a CSS selector that must exist inside the preview, or
+ * - a self-contained predicate that can run in browser context.
+ */
+export async function findPreviewIndex(
+  page: any,
+  match: string | ((preview: Element) => boolean),
+): Promise<number> {
+  const index: number | null =
+    typeof match === "string"
+      ? await page.evaluate((selector: string) => {
+          const previews = Array.from(
+            document.querySelectorAll('[data-slot="preview"]'),
+          );
+          for (let i = 0; i < previews.length; i++) {
+            if (previews[i].querySelector(selector)) return i;
+          }
+          return null;
+        }, match)
+      : await page.evaluate((predicateSource: string) => {
+          const predicate = new Function(`return (${predicateSource});`)() as (
+            preview: Element,
+          ) => boolean;
+          const previews = Array.from(
+            document.querySelectorAll('[data-slot="preview"]'),
+          );
+          for (let i = 0; i < previews.length; i++) {
+            if (predicate(previews[i])) return i;
+          }
+          return null;
+        }, match.toString());
+
+  if (index === null) {
+    const hint =
+      typeof match === "string"
+        ? `innerSelector: ${match}`
+        : "predicate returned false for all previews";
+    throw new Error(`No [data-slot="preview"] matched — ${hint}`);
+  }
+
+  return index;
+}
+
 export async function humanHover(
   ctx: TestContext,
   point: { x: number; y: number },

--- a/packages/voreux/src/browser-grounded.ts
+++ b/packages/voreux/src/browser-grounded.ts
@@ -220,17 +220,29 @@ export function createArtifactPath(dir: string, name: string): string {
   return path.join(dir, `${sanitizeArtifactName(name)}.png`);
 }
 
+type PreviewMatch =
+  | string
+  | {
+      targetSelector: string;
+      buttonTextsAll?: string[];
+      selectorCounts?: Array<{
+        selector: string;
+        equals?: number;
+        atLeast?: number;
+      }>;
+    };
+
 /**
  * Find the 0-based index of the first `[data-slot="preview"]` element
  * matching the given criteria.
  *
  * `match` may be either:
  * - a CSS selector that must exist inside the preview, or
- * - a self-contained predicate that can run in browser context.
+ * - a small serializable matcher object scoped by `targetSelector`.
  */
 export async function findPreviewIndex(
   page: any,
-  match: string | ((preview: Element) => boolean),
+  match: PreviewMatch,
 ): Promise<number> {
   const index: number | null =
     typeof match === "string"
@@ -243,24 +255,49 @@ export async function findPreviewIndex(
           }
           return null;
         }, match)
-      : await page.evaluate((predicateSource: string) => {
-          const predicate = new Function(`return (${predicateSource});`)() as (
-            preview: Element,
-          ) => boolean;
+      : await page.evaluate((criteria: Exclude<PreviewMatch, string>) => {
           const previews = Array.from(
             document.querySelectorAll('[data-slot="preview"]'),
           );
           for (let i = 0; i < previews.length; i++) {
-            if (predicate(previews[i])) return i;
+            const target = previews[i].querySelector(criteria.targetSelector);
+            if (!target) continue;
+
+            if (criteria.buttonTextsAll && criteria.buttonTextsAll.length > 0) {
+              const texts = Array.from(target.querySelectorAll("button")).map(
+                (el) => (el.textContent || "").trim(),
+              );
+              if (
+                !criteria.buttonTextsAll.every((text) => texts.includes(text))
+              ) {
+                continue;
+              }
+            }
+
+            if (criteria.selectorCounts) {
+              const countsSatisfied = criteria.selectorCounts.every((entry) => {
+                const count = target.querySelectorAll(entry.selector).length;
+                if (entry.equals !== undefined && count !== entry.equals) {
+                  return false;
+                }
+                if (entry.atLeast !== undefined && count < entry.atLeast) {
+                  return false;
+                }
+                return true;
+              });
+              if (!countsSatisfied) continue;
+            }
+
+            return i;
           }
           return null;
-        }, match.toString());
+        }, match);
 
   if (index === null) {
     const hint =
       typeof match === "string"
         ? `innerSelector: ${match}`
-        : "predicate returned false for all previews";
+        : `targetSelector: ${match.targetSelector}`;
     throw new Error(`No [data-slot="preview"] matched — ${hint}`);
   }
 

--- a/packages/voreux/src/index.ts
+++ b/packages/voreux/src/index.ts
@@ -2,6 +2,7 @@ export {
   clearPointerHover,
   createArtifactPath,
   ensureDir,
+  findPreviewIndex,
   findSelectByOptionValues,
   getCenterPoint,
   getClosestToContainerCenter,

--- a/packages/voreux/tests/browser-grounded.test.ts
+++ b/packages/voreux/tests/browser-grounded.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { findPreviewIndex } from "../src/index.js";
+
+type PreviewSpec = {
+  selectors?: string[];
+  buttonTexts?: string[];
+};
+
+function mockPage(previews: PreviewSpec[]) {
+  function createPreview(spec: PreviewSpec) {
+    const preview = {
+      querySelector(selector: string) {
+        return spec.selectors?.includes(selector) ? preview : null;
+      },
+      querySelectorAll(selector: string) {
+        if (selector === "button") {
+          return (spec.buttonTexts ?? []).map((text) => ({
+            textContent: text,
+          }));
+        }
+        return [];
+      },
+    };
+
+    return preview;
+  }
+
+  return {
+    async evaluate(fn: (...args: any[]) => any, arg?: unknown) {
+      const fakeDocument = {
+        querySelectorAll(selector: string) {
+          if (selector === '[data-slot="preview"]') {
+            return previews.map(createPreview);
+          }
+          return [];
+        },
+      };
+
+      const globals = globalThis as typeof globalThis & {
+        document?: unknown;
+        Function: typeof Function;
+      };
+      const originalDocument = globals.document;
+      const originalFunction = globals.Function;
+
+      globals.document = fakeDocument;
+      // biome-ignore lint/complexity/useArrowFunction: constructable test shim
+      globals.Function = function (body: string) {
+        const match = body.match(/^return \((.*)\);$/s);
+        if (!match) {
+          return originalFunction(body);
+        }
+        // biome-ignore lint/security/noGlobalEval: test-only predicate shim
+        return () => eval(`(${match[1]})`);
+      } as typeof Function;
+
+      try {
+        return arg === undefined ? fn() : fn(arg);
+      } finally {
+        if (originalDocument === undefined) {
+          delete globals.document;
+        } else {
+          globals.document = originalDocument;
+        }
+        globals.Function = originalFunction;
+      }
+    },
+  };
+}
+
+describe("findPreviewIndex", () => {
+  it("returns index of first preview containing the selector", async () => {
+    const page = mockPage([
+      { selectors: ['[data-slot="tooltip"]'] },
+      { selectors: ['[data-slot="calendar"]'] },
+      { selectors: ['[data-slot="calendar"]'] },
+    ]);
+
+    await expect(
+      findPreviewIndex(page, '[data-slot="calendar"]'),
+    ).resolves.toBe(1);
+  });
+
+  it("returns index of first preview passing predicate", async () => {
+    const page = mockPage([
+      { selectors: ['[data-slot="button-group"]'], buttonTexts: ["Other"] },
+      {
+        selectors: ['[data-slot="button-group"]'],
+        buttonTexts: ["Archive", "Report", "Snooze"],
+      },
+    ]);
+
+    await expect(
+      findPreviewIndex(page, (preview) => {
+        const group = preview.querySelector(
+          '[data-slot="button-group"]',
+        ) as Element | null;
+        if (!group) return false;
+        const texts = Array.from(group.querySelectorAll("button")).map((el) =>
+          (el.textContent || "").trim(),
+        );
+        return (
+          texts.includes("Archive") &&
+          texts.includes("Report") &&
+          texts.includes("Snooze")
+        );
+      }),
+    ).resolves.toBe(1);
+  });
+
+  it("throws when no preview matches", async () => {
+    const page = mockPage([{ selectors: ['[data-slot="tooltip"]'] }]);
+
+    await expect(
+      findPreviewIndex(page, '[data-slot="calendar"]'),
+    ).rejects.toThrow('No [data-slot="preview"] matched');
+  });
+});

--- a/packages/voreux/tests/browser-grounded.test.ts
+++ b/packages/voreux/tests/browser-grounded.test.ts
@@ -4,25 +4,33 @@ import { findPreviewIndex } from "../src/index.js";
 type PreviewSpec = {
   selectors?: string[];
   buttonTexts?: string[];
+  counts?: Record<string, number>;
 };
+
+function createMockElement(spec: PreviewSpec) {
+  const element = {
+    querySelector(selector: string) {
+      return spec.selectors?.includes(selector)
+        ? createMockElement(spec)
+        : null;
+    },
+    querySelectorAll(selector: string) {
+      if (selector === "button") {
+        return (spec.buttonTexts ?? []).map((text) => ({
+          textContent: text,
+        }));
+      }
+      const count = spec.counts?.[selector] ?? 0;
+      return Array.from({ length: count }, () => createMockElement({}));
+    },
+  };
+
+  return element;
+}
 
 function mockPage(previews: PreviewSpec[]) {
   function createPreview(spec: PreviewSpec) {
-    const preview = {
-      querySelector(selector: string) {
-        return spec.selectors?.includes(selector) ? preview : null;
-      },
-      querySelectorAll(selector: string) {
-        if (selector === "button") {
-          return (spec.buttonTexts ?? []).map((text) => ({
-            textContent: text,
-          }));
-        }
-        return [];
-      },
-    };
-
-    return preview;
+    return createMockElement(spec);
   }
 
   return {
@@ -81,7 +89,7 @@ describe("findPreviewIndex", () => {
     ).resolves.toBe(1);
   });
 
-  it("returns index of first preview passing predicate", async () => {
+  it("returns index of first preview matching structured criteria", async () => {
     const page = mockPage([
       { selectors: ['[data-slot="button-group"]'], buttonTexts: ["Other"] },
       {
@@ -91,19 +99,32 @@ describe("findPreviewIndex", () => {
     ]);
 
     await expect(
-      findPreviewIndex(page, (preview) => {
-        const group = preview.querySelector(
-          '[data-slot="button-group"]',
-        ) as Element | null;
-        if (!group) return false;
-        const texts = Array.from(group.querySelectorAll("button")).map((el) =>
-          (el.textContent || "").trim(),
-        );
-        return (
-          texts.includes("Archive") &&
-          texts.includes("Report") &&
-          texts.includes("Snooze")
-        );
+      findPreviewIndex(page, {
+        targetSelector: '[data-slot="button-group"]',
+        buttonTextsAll: ["Archive", "Report", "Snooze"],
+      }),
+    ).resolves.toBe(1);
+  });
+
+  it("supports selector count constraints", async () => {
+    const page = mockPage([
+      {
+        selectors: ['[data-slot="calendar"][data-mode="single"]'],
+        counts: { 'table[role="grid"]': 2, select: 2 },
+      },
+      {
+        selectors: ['[data-slot="calendar"][data-mode="single"]'],
+        counts: { 'table[role="grid"]': 1, select: 2 },
+      },
+    ]);
+
+    await expect(
+      findPreviewIndex(page, {
+        targetSelector: '[data-slot="calendar"][data-mode="single"]',
+        selectorCounts: [
+          { selector: 'table[role="grid"]', equals: 1 },
+          { selector: "select", atLeast: 2 },
+        ],
       }),
     ).resolves.toBe(1);
   });

--- a/packages/voreux/tests/public-api.test.ts
+++ b/packages/voreux/tests/public-api.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { defineScenarioSuite } from "../src/index.js";
+import { defineScenarioSuite, findPreviewIndex } from "../src/index.js";
 
 describe("voreux public api", () => {
   it("exports defineScenarioSuite", () => {
     expect(typeof defineScenarioSuite).toBe("function");
+  });
+
+  it("exports findPreviewIndex", () => {
+    expect(typeof findPreviewIndex).toBe("function");
   });
 });


### PR DESCRIPTION
## Summary
- add `findPreviewIndex` as a reusable preview/demo selection helper in the core browser-grounded helpers
- export the helper publicly and add focused tests for selector and predicate matching
- migrate shadcn button-group and calendar sample helpers to use the shared preview selection path

## Validation
- `pnpm --filter @uzulla/voreux test`
- `pnpm --filter @uzulla/voreux build`
- `pnpm --filter @uzulla/voreux exec tsc -p tsconfig.json --noEmit`
- `pnpm exec biome check packages/voreux/src/browser-grounded.ts packages/voreux/src/index.ts packages/voreux/tests/public-api.test.ts packages/voreux/tests/browser-grounded.test.ts examples/shadcn-component/tests/button-group-helpers.ts examples/shadcn-component/tests/calendar-helpers.ts`
- `coderabbit review --plain`

Closes #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリース ノート

* **New Features**
  * 新しいプレビュー検索ヘルパーを公開し、特定のプレビューを直接特定できるようになりました。

* **Tests**
  * プレビュー検索に関する網羅的なテストを追加し、複数ケースでの動作を検証しました。

* **Refactor**
  * テスト用ユーティリティとボタン／カレンダー操作ロジックを見直し、正しいプレビューに対して要素操作を行うよう改善・安定化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uzulla/voreux/pull/63)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->