### PR TITLE
docs: clarify branch and breaking-change PR rules

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -232,6 +232,9 @@ If a suggestion is not adopted:
 This repo uses Biome, and formatting misses have already caused CI failures.
 Treat formatting and static checks as mandatory, not optional cleanup.
 
+Do not work directly on the default branch (`main`).
+Create a topic branch first, then commit and open a PR from that branch.
+
 Before push, and ideally before commit, run the repo checks that matter for the files you changed.
 At minimum, if you touched code or docs that Biome checks, run:
 
@@ -261,6 +264,14 @@ Prefer including:
 - which sample or scenario was used
 - what files were selected or excluded
 - what visibly happened or what the test result was
+
+If the PR contains a breaking change, make that impossible to miss.
+At minimum:
+
+- put `BREAKING CHANGE:` near the top of the PR body
+- describe the impact scope clearly
+- describe the migration path or required caller changes
+- prefer a PR title that also signals the breaking nature of the change
 
 In other words, include not only "what was implemented" but also "how it actually behaved when run".
 This makes review easier and fits this repo's nature as an executable example/testing library.


### PR DESCRIPTION
## Summary
- clarify that contributors should not work directly on `main`
- document that breaking changes must be called out prominently in PR titles/bodies

## Validation
- `coderabbit review --plain`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

この変更は内部開発プロセスのドキュメント更新です。エンドユーザーに直接の影響はありません。

* **Documentation**
  * 貢献者向けワークフローガイダンスを更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uzulla/voreux/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->