### PR TITLE
feat: add visual state helper

### DIFF
--- a/examples/shadcn-component/tests/alert-dialog-helpers.ts
+++ b/examples/shadcn-component/tests/alert-dialog-helpers.ts
@@ -4,6 +4,7 @@ import {
   createArtifactPath,
   ensureDir,
   getCenterPoint,
+  readElementVisualState,
   waitUntil,
 } from "@uzulla/voreux";
 
@@ -148,7 +149,7 @@ export async function getOverlayVisualState(page: any): Promise<{
   backdropFilter: string;
   backgroundColor: string;
 }> {
-  return page.evaluate(() => {
+  const index = await page.evaluate(() => {
     const isVisible = (el: HTMLElement) => {
       const cs = getComputedStyle(el);
       const rect = el.getBoundingClientRect();
@@ -161,19 +162,26 @@ export async function getOverlayVisualState(page: any): Promise<{
       );
     };
 
-    const overlay = Array.from(
+    return Array.from(
       document.querySelectorAll('[data-slot="alert-dialog-overlay"]'),
-    ).find((el) => isVisible(el as HTMLElement)) as HTMLElement | undefined;
-    if (!overlay) {
-      return { visible: false, backdropFilter: "", backgroundColor: "" };
-    }
-    const cs = getComputedStyle(overlay);
-    return {
-      visible: true,
-      backdropFilter: cs.backdropFilter,
-      backgroundColor: cs.backgroundColor,
-    };
+    ).findIndex((el) => isVisible(el as HTMLElement));
   });
+  if (index < 0) {
+    return { visible: false, backdropFilter: "", backgroundColor: "" };
+  }
+
+  const state = await readElementVisualState(page, {
+    rootSelector: '[data-slot="alert-dialog-overlay"]',
+    rootIndex: index,
+    selector: ":scope",
+    css: ["backdrop-filter", "background-color"],
+  });
+
+  return {
+    visible: state.visible,
+    backdropFilter: state.css["backdrop-filter"] ?? "",
+    backgroundColor: state.css["background-color"] ?? "",
+  };
 }
 
 /**

--- a/examples/shadcn-component/tests/button-group-helpers.ts
+++ b/examples/shadcn-component/tests/button-group-helpers.ts
@@ -2,6 +2,7 @@ import {
   findPreviewIndex,
   getCenterPoint,
   humanHover,
+  readElementVisualState,
   type TestContext,
   waitUntil,
 } from "@uzulla/voreux";
@@ -139,7 +140,7 @@ export async function getButtonVisualState(
   matchesHover: boolean;
 }> {
   const previewIndex = await findButtonGroupPreviewIndex(page);
-  return page.evaluate(
+  const state = await page.evaluate(
     (args: { previewIndex: number; targetLabel: string }) => {
       const preview = document.querySelectorAll('[data-slot="preview"]')[
         args.previewIndex
@@ -150,16 +151,32 @@ export async function getButtonVisualState(
       const button = Array.from(group?.querySelectorAll("button") ?? []).find(
         (el) => (el.textContent || "").trim() === args.targetLabel,
       ) as HTMLElement | undefined;
-      if (!button) throw new Error(`button not found: ${args.targetLabel}`);
-      const cs = getComputedStyle(button);
+      if (!button) return null;
+      const buttons = Array.from(group?.querySelectorAll("button") ?? []);
+      const targetIndex = buttons.indexOf(button);
       return {
-        backgroundColor: cs.backgroundColor,
-        color: cs.color,
-        matchesHover: button.matches(":hover"),
+        previewIndex: args.previewIndex,
+        targetIndex,
       };
     },
     { previewIndex, targetLabel: label },
   );
+  if (!state) throw new Error(`button not found: ${label}`);
+
+  const visual = await readElementVisualState(page, {
+    rootSelector: '[data-slot="preview"]',
+    rootIndex: state.previewIndex,
+    selector: `[data-slot="button-group"] button:nth-of-type(${state.targetIndex + 1})`,
+    css: ["background-color", "color"],
+    matches: [":hover"],
+  });
+  if (!visual.found) throw new Error(`button visual state not found: ${label}`);
+
+  return {
+    backgroundColor: visual.css["background-color"] ?? "",
+    color: visual.css.color ?? "",
+    matchesHover: visual.matches[":hover"] ?? false,
+  };
 }
 
 export async function waitForMenuVisible(page: any): Promise<void> {

--- a/examples/shadcn-component/tests/button-group-helpers.ts
+++ b/examples/shadcn-component/tests/button-group-helpers.ts
@@ -163,6 +163,8 @@ export async function getButtonVisualState(
   );
   if (!state) throw new Error(`button not found: ${label}`);
 
+  // Use nth-of-type here because the preview renders the button-group as
+  // flat sibling buttons; this would need revisiting if buttons became nested.
   const visual = await readElementVisualState(page, {
     rootSelector: '[data-slot="preview"]',
     rootIndex: state.previewIndex,

--- a/examples/shadcn-component/tests/carousel-helpers.ts
+++ b/examples/shadcn-component/tests/carousel-helpers.ts
@@ -4,6 +4,7 @@ import {
   createArtifactPath,
   ensureDir,
   getClosestToContainerCenter,
+  readElementVisualState,
   screenshotClipAroundBox,
   waitUntil,
 } from "@uzulla/voreux";
@@ -141,26 +142,19 @@ export async function getButtonVisualState(
   slot: "carousel-next" | "carousel-previous",
 ): Promise<{ disabled: boolean; opacity: string; pointerEvents: string }> {
   const index = await getTargetCarousel(page);
-  const state = await page.evaluate(
-    (args: { i: number; slot: string }) => {
-      const carousel = document.querySelectorAll('[data-slot="carousel"]')[
-        args.i
-      ] as HTMLElement | undefined;
-      const button = carousel?.querySelector(
-        `[data-slot="${args.slot}"]`,
-      ) as HTMLButtonElement | null;
-      if (!button) return null;
-      const cs = getComputedStyle(button);
-      return {
-        disabled: button.hasAttribute("disabled"),
-        opacity: cs.opacity,
-        pointerEvents: cs.pointerEvents,
-      };
-    },
-    { i: index, slot },
-  );
-  if (!state) throw new Error(`button state not found: ${slot}`);
-  return state;
+  const state = await readElementVisualState(page, {
+    rootSelector: '[data-slot="carousel"]',
+    rootIndex: index,
+    selector: `[data-slot="${slot}"]`,
+    css: ["opacity", "pointer-events"],
+    attributes: ["disabled"],
+  });
+  if (!state.found) throw new Error(`button state not found: ${slot}`);
+  return {
+    disabled: state.attributes.disabled !== null,
+    opacity: state.css.opacity ?? "",
+    pointerEvents: state.css["pointer-events"] ?? "",
+  };
 }
 
 /**

--- a/packages/voreux/src/browser-grounded.ts
+++ b/packages/voreux/src/browser-grounded.ts
@@ -148,7 +148,10 @@ export async function readElementVisualState(
             | HTMLElement
             | undefined) ?? null)
         : document;
-      const target = root?.querySelector(args.selector) as HTMLElement | null;
+      const target =
+        args.selector === ":scope" || args.selector === ""
+          ? (root && root !== document ? (root as HTMLElement) : null)
+          : (root?.querySelector(args.selector) as HTMLElement | null);
       if (!target) {
         return {
           found: false,

--- a/packages/voreux/src/browser-grounded.ts
+++ b/packages/voreux/src/browser-grounded.ts
@@ -117,6 +117,86 @@ export async function isPerceivablyVisible(
   }, selector);
 }
 
+export async function readElementVisualState(
+  page: any,
+  opts: {
+    selector: string;
+    rootSelector?: string;
+    rootIndex?: number;
+    css?: string[];
+    attributes?: string[];
+    matches?: string[];
+  },
+): Promise<{
+  found: boolean;
+  visible: boolean;
+  css: Record<string, string>;
+  attributes: Record<string, string | null>;
+  matches: Record<string, boolean>;
+}> {
+  return page.evaluate(
+    (args: {
+      selector: string;
+      rootSelector?: string;
+      rootIndex?: number;
+      css: string[];
+      attributes: string[];
+      matches: string[];
+    }) => {
+      const root = args.rootSelector
+        ? ((document.querySelectorAll(args.rootSelector)[args.rootIndex ?? 0] as
+            | HTMLElement
+            | undefined) ?? null)
+        : document;
+      const target = root?.querySelector(args.selector) as HTMLElement | null;
+      if (!target) {
+        return {
+          found: false,
+          visible: false,
+          css: {},
+          attributes: {},
+          matches: {},
+        };
+      }
+
+      const computed = getComputedStyle(target);
+      const rect = target.getBoundingClientRect();
+      const visible =
+        computed.display !== "none" &&
+        computed.visibility !== "hidden" &&
+        computed.opacity !== "0" &&
+        rect.width > 0 &&
+        rect.height > 0;
+
+      const css = Object.fromEntries(
+        args.css.map((name) => [name, computed.getPropertyValue(name)]),
+      );
+      const attributes = Object.fromEntries(
+        args.attributes.map((name) => [name, target.getAttribute(name)]),
+      );
+      const matches = Object.fromEntries(
+        args.matches.map((selector) => [selector, target.matches(selector)]),
+      );
+
+      return {
+        found: true,
+        visible,
+        css,
+        attributes,
+        matches,
+      };
+    },
+    {
+      selector: opts.selector,
+      rootSelector: opts.rootSelector,
+      rootIndex: opts.rootIndex,
+      css: opts.css ?? [],
+      attributes: opts.attributes ?? [],
+      matches: opts.matches ?? [],
+    },
+  );
+}
+
 export async function getClosestToContainerCenter(
   page: any,
   opts: {

--- a/packages/voreux/src/browser-grounded.ts
+++ b/packages/voreux/src/browser-grounded.ts
@@ -150,7 +150,9 @@ export async function readElementVisualState(
         : document;
       const target =
         args.selector === ":scope" || args.selector === ""
-          ? (root && root !== document ? (root as HTMLElement) : null)
+          ? root && root !== document
+            ? (root as HTMLElement)
+            : null
           : (root?.querySelector(args.selector) as HTMLElement | null);
       if (!target) {
         return {

--- a/packages/voreux/src/index.ts
+++ b/packages/voreux/src/index.ts
@@ -9,6 +9,7 @@ export {
   humanHover,
   isPerceivablyVisible,
   movePointerToSafeCorner,
+  readElementVisualState,
   screenshotClip,
   screenshotClipAroundBox,
   waitUntil,

--- a/packages/voreux/tests/browser-grounded.test.ts
+++ b/packages/voreux/tests/browser-grounded.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { findPreviewIndex } from "../src/index.js";
+import { findPreviewIndex, readElementVisualState } from "../src/index.js";
 
-type PreviewSpec = {
+type ElementSpec = {
   selectors?: string[];
   buttonTexts?: string[];
   counts?: Record<string, number>;
+  children?: Record<string, ElementSpec>;
+  computedStyle?: Record<string, string>;
+  attributes?: Record<string, string | null>;
+  matches?: Record<string, boolean>;
+  rect?: { width: number; height: number };
 };
 
-function createMockElement(spec: PreviewSpec) {
+function createMockElement(spec: ElementSpec) {
   const element = {
+    __spec: spec,
     querySelector(selector: string) {
+      if (spec.children?.[selector]) {
+        return createMockElement(spec.children[selector]);
+      }
       return spec.selectors?.includes(selector)
         ? createMockElement(spec)
         : null;
@@ -20,47 +29,78 @@ function createMockElement(spec: PreviewSpec) {
           textContent: text,
         }));
       }
+      if (spec.children?.[selector]) {
+        return [createMockElement(spec.children[selector])];
+      }
       const count = spec.counts?.[selector] ?? 0;
       return Array.from({ length: count }, () => createMockElement({}));
+    },
+    getBoundingClientRect() {
+      return {
+        width: spec.rect?.width ?? 10,
+        height: spec.rect?.height ?? 10,
+      };
+    },
+    getAttribute(name: string) {
+      return spec.attributes?.[name] ?? null;
+    },
+    matches(selector: string) {
+      return spec.matches?.[selector] ?? false;
     },
   };
 
   return element;
 }
 
-function mockPage(previews: PreviewSpec[]) {
-  function createPreview(spec: PreviewSpec) {
-    return createMockElement(spec);
-  }
-
+function mockPage(previews: ElementSpec[]) {
   return {
     async evaluate(fn: (...args: any[]) => any, arg?: unknown) {
       const fakeDocument = {
         querySelectorAll(selector: string) {
           if (selector === '[data-slot="preview"]') {
-            return previews.map(createPreview);
+            return previews.map((preview) => createMockElement(preview));
           }
           return [];
+        },
+        querySelector(selector: string) {
+          return selector === '[data-slot="standalone"]'
+            ? createMockElement({
+                computedStyle: {
+                  display: "block",
+                  visibility: "visible",
+                  opacity: "1",
+                  color: "rgb(1, 2, 3)",
+                },
+                rect: { width: 20, height: 20 },
+              })
+            : null;
         },
       };
 
       const globals = globalThis as typeof globalThis & {
         document?: unknown;
-        Function: typeof Function;
+        getComputedStyle?: (element: { __spec?: ElementSpec }) => {
+          display: string;
+          visibility: string;
+          opacity: string;
+          getPropertyValue: (name: string) => string;
+        };
       };
       const originalDocument = globals.document;
-      const originalFunction = globals.Function;
+      const originalGetComputedStyle = globalThis.getComputedStyle;
 
       globals.document = fakeDocument;
-      // biome-ignore lint/complexity/useArrowFunction: constructable test shim
-      globals.Function = function (body: string) {
-        const match = body.match(/^return \((.*)\);$/s);
-        if (!match) {
-          return originalFunction(body);
-        }
-        // biome-ignore lint/security/noGlobalEval: test-only predicate shim
-        return () => eval(`(${match[1]})`);
-      } as typeof Function;
+      globalThis.getComputedStyle = ((element: { __spec?: ElementSpec }) => {
+        const computed = element.__spec?.computedStyle ?? {};
+        return {
+          display: computed.display ?? "block",
+          visibility: computed.visibility ?? "visible",
+          opacity: computed.opacity ?? "1",
+          getPropertyValue(name: string) {
+            return computed[name] ?? "";
+          },
+        };
+      }) as typeof globalThis.getComputedStyle;
 
       try {
         return arg === undefined ? fn() : fn(arg);
@@ -70,7 +110,7 @@ function mockPage(previews: PreviewSpec[]) {
         } else {
           globals.document = originalDocument;
         }
-        globals.Function = originalFunction;
+        globalThis.getComputedStyle = originalGetComputedStyle;
       }
     },
   };
@@ -135,5 +175,81 @@ describe("findPreviewIndex", () => {
     await expect(
       findPreviewIndex(page, '[data-slot="calendar"]'),
     ).rejects.toThrow('No [data-slot="preview"] matched');
+  });
+});
+
+describe("readElementVisualState", () => {
+  it("reads css, attributes, matches, and visibility inside a preview root", async () => {
+    const page = mockPage([
+      {},
+      {
+        children: {
+          '[data-slot="button-group"]': {
+            children: {
+              'button[data-test="archive"]': {
+                computedStyle: {
+                  display: "block",
+                  visibility: "visible",
+                  opacity: "0.5",
+                  "background-color": "rgb(0, 0, 0)",
+                  color: "rgb(255, 255, 255)",
+                },
+                attributes: { disabled: "" },
+                matches: { ":hover": true },
+                rect: { width: 24, height: 24 },
+              },
+            },
+          },
+          'button[data-test="archive"]': {
+            computedStyle: {
+              display: "block",
+              visibility: "visible",
+              opacity: "0.5",
+              "background-color": "rgb(0, 0, 0)",
+              color: "rgb(255, 255, 255)",
+            },
+            attributes: { disabled: "" },
+            matches: { ":hover": true },
+            rect: { width: 24, height: 24 },
+          },
+        },
+      },
+    ]);
+
+    const state = await readElementVisualState(page, {
+      rootSelector: '[data-slot="preview"]',
+      rootIndex: 1,
+      selector: 'button[data-test="archive"]',
+      css: ["background-color", "color", "opacity"],
+      attributes: ["disabled"],
+      matches: [":hover"],
+    });
+
+    expect(state.found).toBe(true);
+    expect(state.visible).toBe(true);
+    expect(state.css["background-color"]).toBe("rgb(0, 0, 0)");
+    expect(state.css.color).toBe("rgb(255, 255, 255)");
+    expect(state.css.opacity).toBe("0.5");
+    expect(state.attributes.disabled).toBe("");
+    expect(state.matches[":hover"]).toBe(true);
+  });
+
+  it("returns not found state when target is missing", async () => {
+    const page = mockPage([{}]);
+
+    const state = await readElementVisualState(page, {
+      rootSelector: '[data-slot="preview"]',
+      rootIndex: 0,
+      selector: '[data-slot="missing"]',
+      css: ["color"],
+      attributes: ["disabled"],
+      matches: [":hover"],
+    });
+
+    expect(state.found).toBe(false);
+    expect(state.visible).toBe(false);
+    expect(state.css).toEqual({});
+    expect(state.attributes).toEqual({});
+    expect(state.matches).toEqual({});
   });
 });

--- a/packages/voreux/tests/browser-grounded.test.ts
+++ b/packages/voreux/tests/browser-grounded.test.ts
@@ -234,6 +234,37 @@ describe("readElementVisualState", () => {
     expect(state.matches[":hover"]).toBe(true);
   });
 
+  it("reads the root element when selector is :scope", async () => {
+    const page = mockPage([
+      {
+        computedStyle: {
+          display: "block",
+          visibility: "visible",
+          opacity: "1",
+          "background-color": "rgb(10, 20, 30)",
+        },
+        attributes: { "data-state": "open" },
+        matches: { ":scope": true },
+        rect: { width: 48, height: 24 },
+      },
+    ]);
+
+    const state = await readElementVisualState(page, {
+      rootSelector: '[data-slot="preview"]',
+      rootIndex: 0,
+      selector: ":scope",
+      css: ["background-color"],
+      attributes: ["data-state"],
+      matches: [":scope"],
+    });
+
+    expect(state.found).toBe(true);
+    expect(state.visible).toBe(true);
+    expect(state.css["background-color"]).toBe("rgb(10, 20, 30)");
+    expect(state.attributes["data-state"]).toBe("open");
+    expect(state.matches[":scope"]).toBe(true);
+  });
+
   it("returns not found state when target is missing", async () => {
     const page = mockPage([{}]);
 

--- a/packages/voreux/tests/public-api.test.ts
+++ b/packages/voreux/tests/public-api.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { defineScenarioSuite, findPreviewIndex } from "../src/index.js";
+import {
+  defineScenarioSuite,
+  findPreviewIndex,
+  readElementVisualState,
+} from "../src/index.js";
 
 describe("voreux public api", () => {
   it("exports defineScenarioSuite", () => {
@@ -8,5 +12,9 @@ describe("voreux public api", () => {
 
   it("exports findPreviewIndex", () => {
     expect(typeof findPreviewIndex).toBe("function");
+  });
+
+  it("exports readElementVisualState", () => {
+    expect(typeof readElementVisualState).toBe("function");
   });
 });


### PR DESCRIPTION
## Summary
- add `readElementVisualState(...)` as a reusable browser-grounded helper for perceptible visual-state reads
- migrate sample-local visual-state readers in `button-group`, `carousel`, and `alert-dialog` to the shared helper
- add focused tests and public API coverage for the new helper

## Validation
- `pnpm --filter @uzulla/voreux test`
- `pnpm --filter @uzulla/voreux build`
- `pnpm --filter @uzulla/voreux exec tsc -p tsconfig.json --noEmit`
- `pnpm exec biome check packages/voreux/src/browser-grounded.ts packages/voreux/src/index.ts packages/voreux/tests/public-api.test.ts packages/voreux/tests/browser-grounded.test.ts examples/shadcn-component/tests/button-group-helpers.ts examples/shadcn-component/tests/carousel-helpers.ts examples/shadcn-component/tests/alert-dialog-helpers.ts`
- `coderabbit review --plain`

Closes #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 要素の視覚的な状態（表示可否・CSS値・属性・セレクタマッチ等）を安定して読み取る新しいヘルパーを追加しました。
  * 既存のUIテストヘルパーをこの読み取り機能に切り替え、視覚スタイル取得の信頼性を向上しました。

* **Tests**
  * テスト基盤を拡張し、視覚状態読み取り・:hoverなどのマッチング・ルートスコープ挙動を検証するテストを追加しました。
* **Public API**
  * 新ヘルパーが公開APIに含まれることを確認するテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uzulla/voreux/pull/66)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->