### PR TITLE
fix: stabilize button-group hover verification

### DIFF
--- a/examples/shadcn-component/tests/button-group-helpers.ts
+++ b/examples/shadcn-component/tests/button-group-helpers.ts
@@ -2,7 +2,6 @@ import {
   findPreviewIndex,
   getCenterPoint,
   humanHover,
-  readElementVisualState,
   type TestContext,
   waitUntil,
 } from "@uzulla/voreux";
@@ -140,7 +139,7 @@ export async function getButtonVisualState(
   matchesHover: boolean;
 }> {
   const previewIndex = await findButtonGroupPreviewIndex(page);
-  const state = await page.evaluate(
+  const visual = await page.evaluate(
     (args: { previewIndex: number; targetLabel: string }) => {
       const preview = document.querySelectorAll('[data-slot="preview"]')[
         args.previewIndex
@@ -152,33 +151,18 @@ export async function getButtonVisualState(
         (el) => (el.textContent || "").trim() === args.targetLabel,
       ) as HTMLElement | undefined;
       if (!button) return null;
-      const buttons = Array.from(group?.querySelectorAll("button") ?? []);
-      const targetIndex = buttons.indexOf(button);
+      const computed = getComputedStyle(button);
       return {
-        previewIndex: args.previewIndex,
-        targetIndex,
+        backgroundColor: computed.backgroundColor,
+        color: computed.color,
+        matchesHover: button.matches(":hover"),
       };
     },
     { previewIndex, targetLabel: label },
   );
-  if (!state) throw new Error(`button not found: ${label}`);
+  if (!visual) throw new Error(`button visual state not found: ${label}`);
 
-  // Use nth-of-type here because the preview renders the button-group as
-  // flat sibling buttons; this would need revisiting if buttons became nested.
-  const visual = await readElementVisualState(page, {
-    rootSelector: '[data-slot="preview"]',
-    rootIndex: state.previewIndex,
-    selector: `[data-slot="button-group"] button:nth-of-type(${state.targetIndex + 1})`,
-    css: ["background-color", "color"],
-    matches: [":hover"],
-  });
-  if (!visual.found) throw new Error(`button visual state not found: ${label}`);
-
-  return {
-    backgroundColor: visual.css["background-color"] ?? "",
-    color: visual.css.color ?? "",
-    matchesHover: visual.matches[":hover"] ?? false,
-  };
+  return visual;
 }
 
 export async function waitForMenuVisible(page: any): Promise<void> {

--- a/examples/shadcn-component/tests/button-group-visual-compare.ts
+++ b/examples/shadcn-component/tests/button-group-visual-compare.ts
@@ -34,9 +34,22 @@ export async function assertArchiveHoverVisualChange(
 
 async function screenshotArchiveButton(page: any, outputPath: string) {
   const clip = await page.evaluate(() => {
-    const preview = document.querySelector(
-      '[data-slot="preview"]',
-    ) as HTMLElement | null;
+    // docs ページには複数の preview があり順序も固定とは限らないため、
+    // index ではなく Archive/Report/Snooze を含む button-group を持つ
+    // preview を意味的に特定して対象を固定する。
+    const previews = Array.from(
+      document.querySelectorAll('[data-slot="preview"]'),
+    );
+    const preview = previews.find((candidate) => {
+      const target = candidate.querySelector('[data-slot="button-group"]');
+      if (!target) return false;
+      const texts = Array.from(target.querySelectorAll("button")).map((el) =>
+        (el.textContent || "").trim(),
+      );
+      return ["Archive", "Report", "Snooze"].every((text) =>
+        texts.includes(text),
+      );
+    }) as HTMLElement | undefined;
     const group = preview?.querySelector(
       '[data-slot="button-group"]',
     ) as HTMLElement | null;


### PR DESCRIPTION
## Summary
- read the Archive button hover state from the exact matched button instead of a fragile `nth-of-type(...)` selector
- make the Archive button VRT clip locate the semantic button-group preview by button labels instead of the first preview index
- document why the preview lookup is content-based in the sample code

## Validation
- `pnpm check`
- `cd examples/shadcn-component && pnpm vitest run tests/button-group.test.ts`
- `cd examples/shadcn-component && pnpm vitest run tests/button-group.test.ts tests/alert-dialog.test.ts`
- `coderabbit review --plain`

Closes #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト

* ボタングループのビジュアル状態検証ロジックが改善され、より堅牢になりました
* 複数のプレビュー要素を含むシナリオでのテスト実行が安定しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uzulla/voreux/pull/68)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->